### PR TITLE
ci: 在 PR 合并后自动清理构建产物并更新权限

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -3,13 +3,14 @@ name: PR Build
 on:
     pull_request_target:
         branches: [master]
-        types: [opened, synchronize, reopened, labeled]
+        types: [opened, synchronize, reopened, labeled, closed]
 
 permissions:
     contents: read
     pull-requests: write
     checks: write
     statuses: write
+    actions: write
 
 env:
     PLUGIN_ID: next-toc
@@ -238,5 +239,83 @@ jobs:
                           repo: context.repo.repo,
                           issue_number: prNumber,
                           body: commentBody
+                        });
+                      }
+
+    # PR 合并后清理构建产物
+    cleanup-artifacts:
+        runs-on: ubuntu-latest
+        if: github.event.action == 'closed' && github.event.pull_request.merged == true
+        steps:
+            - name: Delete PR build artifacts
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const prNumber = context.payload.pull_request.number;
+
+                      // 获取工作流运行列表
+                      const workflowRuns = await github.rest.actions.listWorkflowRuns({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        workflow_id: 'pr-build.yml',
+                        head_sha: context.payload.pull_request.head.sha
+                      });
+
+                      console.log(`Found ${workflowRuns.data.workflow_runs.length} workflow runs for PR #${prNumber}`);
+
+                      // 遍历工作流运行，删除相关的构建产物
+                      for (const run of workflowRuns.data.workflow_runs) {
+                        try {
+                          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            run_id: run.id
+                          });
+                          
+                          console.log(`Run ${run.id}: Found ${artifacts.data.artifacts.length} artifacts`);
+                          
+                          for (const artifact of artifacts.data.artifacts) {
+                            // 只删除 PR 构建产物（以 plugin-id-pr- 开头的）
+                            if (artifact.name.includes('${{ env.PLUGIN_ID }}-pr-')) {
+                              console.log(`Deleting artifact: ${artifact.name} (ID: ${artifact.id})`);
+                              await github.rest.actions.deleteArtifact({
+                                owner: context.repo.owner,
+                                repo: context.repo.repo,
+                                artifact_id: artifact.id
+                              });
+                            }
+                          }
+                        } catch (error) {
+                          console.log(`Error processing run ${run.id}: ${error.message}`);
+                          // 继续处理其他运行，不因单个错误而停止
+                        }
+                      }
+
+            - name: Update PR comment
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const prNumber = context.payload.pull_request.number;
+
+                      // 查找现有的构建评论
+                      const comments = await github.rest.issues.listComments({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: prNumber
+                      });
+
+                      const existingComment = comments.data.find(comment => 
+                        comment.user.login === 'github-actions[bot]' && 
+                        comment.body.includes('🔧 PR 构建完成')
+                      );
+
+                      if (existingComment) {
+                        const updatedBody = existingComment.body + `\n\n---\n\n✅ **PR 已合并，构建产物已自动清理**`;
+                        
+                        await github.rest.issues.updateComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          comment_id: existingComment.id,
+                          body: updatedBody
                         });
                       }


### PR DESCRIPTION
- 在 pr-build workflow 的触发类型中加入 closed，以便在 PR 关闭/合并时运行相关
  步骤
- 为 workflow 增加 actions 权限写入，确保脚本可以删除 artifact 并更新评论
- 新增 cleanup-artifacts job：
  - 仅在 PR 被合并（closed 且 merged == true）时运行
  - 列出与该 PR head sha 相关的 workflow runs，遍历并删除名称包含
    ${ env.PLUGIN_ID }-pr- 的构建产物，删除时对错误进行捕获并继续处理其他运行
  - 在找到由 github-actions[bot] 发布且包含“🔧 PR 构建完成”的评论后，向其追加
    “✅ PR 已合并，构建产物已自动清理”以告知用户清理结果

这些改动用于在 PR 合并后自动清理无用的 CI 构建产物，减少存储占用并在 PR
页面上明确反馈清理结果。