### PR TITLE
feat: beta版本允许在移动端使用

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -9,5 +9,5 @@
 	"fundingUrl": {
 		"微信/支付宝": "https://s2.loli.net/2024/05/06/lWBj3ObszUXSV2f.png"
 	},
-	"isDesktopOnly": true
+	"isDesktopOnly": false
 }


### PR DESCRIPTION
将 manifest-beta 中 isDesktopOnly 字段由 true 改为
false，使应用不再限制仅在面端可用。此修改用于扩展安装范围，移动端用户并提高可访问性与用户
覆盖率。