### PR TITLE
feat(i18n): 统一命名为驼峰命令键

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -3,14 +3,14 @@ import { BaseMessage } from "../types";
 // Remember [use sentence case in UI](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Use+sentence+case+in+UI)
 const translations: BaseMessage = {
 	commands: {
-		"return-to-cursor": "Return to cursor",
-		"scroll-to-top": "Scroll to top",
-		"scroll-to-bottom": "Scroll to bottom",
-		"navigate-previous-heading": "Navigate to previous heading",
-		"navigate-next-heading": "Navigate to next heading",
-		"toc-expand": "Expand/Collapse TOC",
-		"insert-reading-time-card": "Insert reading time card",
-		"insert-table-of-contents-card": "Insert table of contents card",
+		returnToCursor: "Return to cursor",
+		scrollToTop: "Scroll to top",
+		scrollToBottom: "Scroll to bottom",
+		navigatePreviousHeading: "Navigate to previous heading",
+		navigateNextHeading: "Navigate to next heading",
+		tocExpand: "Expand/Collapse TOC",
+		insertReadingTimeCard: "Insert reading time card",
+		insertTableOfContentsCard: "Insert table of contents card",
 	},
 	settings: {
 		toc: {

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -2,14 +2,14 @@ import { BaseMessage } from "../types";
 
 const translations: BaseMessage = {
 	commands: {
-		"return-to-cursor": "返回游標位置",
-		"scroll-to-top": "捲動到頂部",
-		"scroll-to-bottom": "捲動到底部",
-		"navigate-previous-heading": "跳至上一個標題",
-		"navigate-next-heading": "跳至下一個標題",
-		"toc-expand": "展開／收合目錄",
-		"insert-reading-time-card": "插入閱讀時間卡片",
-		"insert-table-of-contents-card": "插入目錄卡片",
+		returnToCursor: "返回游標位置",
+		scrollToTop: "捲動到頂部",
+		scrollToBottom: "捲動到底部",
+		navigatePreviousHeading: "跳至上一個標題",
+		navigateNextHeading: "跳至下一個標題",
+		tocExpand: "展開／收合目錄",
+		insertReadingTimeCard: "插入閱讀時間卡片",
+		insertTableOfContentsCard: "插入目錄卡片",
 	},
 	settings: {
 		toc: {

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -2,14 +2,14 @@ import { BaseMessage } from "../types";
 
 const translations: BaseMessage = {
 	commands: {
-		"return-to-cursor": "返回光标位置",
-		"scroll-to-top": "滚动到顶部",
-		"scroll-to-bottom": "滚动到底部",
-		"navigate-previous-heading": "导航到上一个标题",
-		"navigate-next-heading": "导航到下一个标题",
-		"toc-expand": "展开/收起目录",
-		"insert-reading-time-card": "插入阅读时间卡片",
-		"insert-table-of-contents-card": "插入目录卡片",
+		returnToCursor: "返回光标位置",
+		scrollToTop: "滚动到顶部",
+		scrollToBottom: "滚动到底部",
+		navigatePreviousHeading: "导航到上一个标题",
+		navigateNextHeading: "导航到下一个标题",
+		tocExpand: "展开/收起目录",
+		insertReadingTimeCard: "插入阅读时间卡片",
+		insertTableOfContentsCard: "插入目录卡片",
 	},
 	settings: {
 		toc: {

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -18,14 +18,14 @@ type SettingsItem<T = Record<string, never>> = IBaseSettingsItem & T;
 // 定义翻译结构类型
 export type BaseMessage = {
 	commands: {
-		"return-to-cursor": string;
-		"scroll-to-top": string;
-		"scroll-to-bottom": string;
-		"navigate-previous-heading": string;
-		"navigate-next-heading": string;
-		"toc-expand": string;
-		"insert-reading-time-card": string;
-		"insert-table-of-contents-card": string;
+		returnToCursor: string;
+		scrollToTop: string;
+		scrollToBottom: string;
+		navigatePreviousHeading: string;
+		navigateNextHeading: string;
+		tocExpand: string;
+		insertReadingTimeCard: string;
+		insertTableOfContentsCard: string;
 	};
 	settings: {
 		toc: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,7 +59,7 @@ export default class NTocPlugin extends Plugin {
 	private registerCommands() {
 		this.addCommand({
 			id: "return-to-cursor",
-			name: t("commands.return-to-cursor"),
+			name: t("commands.returnToCursor"),
 			hotkeys: [],
 			editorCallback: (editor: Editor) => {
 				if (this.currentView && editor === this.currentView.editor) {
@@ -70,7 +70,7 @@ export default class NTocPlugin extends Plugin {
 
 		this.addCommand({
 			id: "scroll-to-top",
-			name: t("commands.scroll-to-top"),
+			name: t("commands.scrollToTop"),
 			hotkeys: [],
 			callback: () => {
 				if (this.currentView) {
@@ -81,7 +81,7 @@ export default class NTocPlugin extends Plugin {
 
 		this.addCommand({
 			id: "scroll-to-bottom",
-			name: t("commands.scroll-to-bottom"),
+			name: t("commands.scrollToBottom"),
 			hotkeys: [],
 			callback: () => {
 				if (this.currentView) {
@@ -92,7 +92,7 @@ export default class NTocPlugin extends Plugin {
 
 		this.addCommand({
 			id: "navigate-previous-heading",
-			name: t("commands.navigate-previous-heading"),
+			name: t("commands.navigatePreviousHeading"),
 			hotkeys: [],
 			callback: async () => {
 				if (this.currentView) {
@@ -104,7 +104,7 @@ export default class NTocPlugin extends Plugin {
 
 		this.addCommand({
 			id: "navigate-next-heading",
-			name: t("commands.navigate-next-heading"),
+			name: t("commands.navigateNextHeading"),
 			hotkeys: [],
 			callback: async () => {
 				if (this.currentView) {
@@ -116,7 +116,7 @@ export default class NTocPlugin extends Plugin {
 
 		this.addCommand({
 			id: "toc-expand",
-			name: t("commands.toc-expand"),
+			name: t("commands.tocExpand"),
 			hotkeys: [],
 			callback: () => {
 				this.settingsStore.updateSettingByPath(
@@ -128,7 +128,7 @@ export default class NTocPlugin extends Plugin {
 
 		this.addCommand({
 			id: "insert-reading-time-card",
-			name: t("commands.insert-reading-time-card"),
+			name: t("commands.insertReadingTimeCard"),
 			editorCallback: (editor: Editor) => {
 				new CardCreateModal(
 					this.app,
@@ -139,7 +139,7 @@ export default class NTocPlugin extends Plugin {
 
 		this.addCommand({
 			id: "insert-table-of-contents-card",
-			name: t("commands.insert-table-of-contents-card"),
+			name: t("commands.insertTableOfContentsCard"),
 			editorCallback: (editor: Editor) => {
 				new CardCreateModal(
 					this.app,
@@ -154,7 +154,7 @@ export default class NTocPlugin extends Plugin {
 			this.app.workspace.on("editor-menu", (menu, editor, view) => {
 				if (view instanceof MarkdownView) {
 					menu.addItem((item) => {
-						item.setTitle(t("commands.insert-reading-time-card"));
+						item.setTitle(t("commands.insertReadingTimeCard"));
 						item.onClick(() => {
 							new CardCreateModal(
 								this.app,
@@ -163,9 +163,7 @@ export default class NTocPlugin extends Plugin {
 						});
 					});
 					menu.addItem((item) => {
-						item.setTitle(
-							t("commands.insert-table-of-contents-card")
-						);
+						item.setTitle(t("commands.insertTableOfContentsCard"));
 						item.onClick(() => {
 							new CardCreateModal(
 								this.app,


### PR DESCRIPTION
将 i18n 键从短横线形式改为驼峰命名，并同步更新
对应类型定义和 main.ts 中的调用处。主要改动包括：
- 修改 src/i18n/locales/en.ts 和 src/i18n/locales/zh.ts
  中 commands 内的键名为 returnToCursor 等驼峰形式。
- 更新 src/i18n/types.ts 中 BaseMessage 的字段为驼峰
  名称以保持类型一致性。
- 更新 src/main.ts 中所有 t("commands.xxx") 的调用为
  t("commands.xxxCamelCase")，以及编辑器菜单项标题的
  调用，确保运行时能正确读取翻译项。

为什么做这些改动：
- 统一键名风格便于代码维护和静态检查，避免因命名
  不一致导致的运行时找不到翻译字符串的问题。