### PR TITLE
refactor: 注释掉卡片相关功能并移除部分导入

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,21 +1,16 @@
 import { EditorView } from "@codemirror/view";
 import "@styles/styles";
 import { Editor, MarkdownView, Plugin } from "obsidian";
-import { CardCreateModal } from "./components/modal/card-modal/CardCreateModal";
 import {
 	NTocRenderProps,
 	updateNTocRender,
 } from "./components/toc-navigator/NTocRender";
 import { t } from "./i18n/i18n";
-import { CardProcessor } from "./services/CardProcessor";
-import { createCursorListenerExtension } from "./services/cursorListenerExtension";
 import { PluginSettingTab } from "./settings/PluginSettingTab";
 import SettingsStore from "./settings/SettingsStore";
-import { DEFAULT_READING_TIME_CARD, DEFAULT_TOC_CARD } from "./types/cards";
 import { NTocPluginSettings } from "./types/types";
 import { createScrollListener } from "./utils/eventListenerManager";
 import getFileHeadings from "./utils/getFileHeadings";
-import mountEditButtonToCodeblock from "./utils/mountEditButtonToCodeblock";
 import {
 	navigateHeading,
 	returnToCursor,
@@ -40,7 +35,7 @@ export default class NTocPlugin extends Plugin {
 		this.registerCodeblockProcessor();
 
 		// Register CM6 cursor listener extension
-		this.registerEditorExtension(createCursorListenerExtension(this));
+		// this.registerEditorExtension(createCursorListenerExtension(this));
 
 		// Setup initial scroll listener
 		this.setupScrollListener();
@@ -126,54 +121,56 @@ export default class NTocPlugin extends Plugin {
 			},
 		});
 
-		this.addCommand({
-			id: "insert-reading-time-card",
-			name: t("commands.insertReadingTimeCard"),
-			editorCallback: (editor: Editor) => {
-				new CardCreateModal(
-					this.app,
-					JSON.stringify(DEFAULT_READING_TIME_CARD)
-				).open();
-			},
-		});
+		// this.addCommand({
+		// 	id: "insert-reading-time-card",
+		// 	name: t("commands.insertReadingTimeCard"),
+		// 	editorCallback: (editor: Editor) => {
+		// 		new CardCreateModal(
+		// 			this.app,
+		// 			JSON.stringify(DEFAULT_READING_TIME_CARD)
+		// 		).open();
+		// 	},
+		// });
 
-		this.addCommand({
-			id: "insert-table-of-contents-card",
-			name: t("commands.insertTableOfContentsCard"),
-			editorCallback: (editor: Editor) => {
-				new CardCreateModal(
-					this.app,
-					JSON.stringify(DEFAULT_TOC_CARD)
-				).open();
-			},
-		});
+		// this.addCommand({
+		// 	id: "insert-table-of-contents-card",
+		// 	name: t("commands.insertTableOfContentsCard"),
+		// 	editorCallback: (editor: Editor) => {
+		// 		new CardCreateModal(
+		// 			this.app,
+		// 			JSON.stringify(DEFAULT_TOC_CARD)
+		// 		).open();
+		// 	},
+		// });
 	}
 
 	private registerContextMenu() {
-		this.registerEvent(
-			this.app.workspace.on("editor-menu", (menu, editor, view) => {
-				if (view instanceof MarkdownView) {
-					menu.addItem((item) => {
-						item.setTitle(t("commands.insertReadingTimeCard"));
-						item.onClick(() => {
-							new CardCreateModal(
-								this.app,
-								JSON.stringify(DEFAULT_READING_TIME_CARD)
-							).open();
-						});
-					});
-					menu.addItem((item) => {
-						item.setTitle(t("commands.insertTableOfContentsCard"));
-						item.onClick(() => {
-							new CardCreateModal(
-								this.app,
-								JSON.stringify(DEFAULT_TOC_CARD)
-							).open();
-						});
-					});
-				}
-			})
-		);
+		// this.registerEvent(
+		// 	this.app.workspace.on("editor-menu", (menu, editor, view) => {
+		// 		if (view instanceof MarkdownView) {
+		// 			menu.addItem((item) => {
+		// 				item.setTitle(t("commands.insertReadingTimeCard"));
+		// 				item.setIcon("clock");
+		// 				item.onClick(() => {
+		// 					new CardCreateModal(
+		// 						this.app,
+		// 						JSON.stringify(DEFAULT_READING_TIME_CARD)
+		// 					).open();
+		// 				});
+		// 			});
+		// 			menu.addItem((item) => {
+		// 				item.setTitle(t("commands.insertTableOfContentsCard"));
+		// 				item.setIcon("table-of-contents");
+		// 				item.onClick(() => {
+		// 					new CardCreateModal(
+		// 						this.app,
+		// 						JSON.stringify(DEFAULT_TOC_CARD)
+		// 					).open();
+		// 				});
+		// 			});
+		// 		}
+		// 	})
+		// );
 	}
 
 	private registerEvents() {
@@ -221,20 +218,20 @@ export default class NTocPlugin extends Plugin {
 	}
 
 	private registerCodeblockProcessor() {
-		this.registerMarkdownCodeBlockProcessor(
-			"ntoc-card",
-			async (code, el, ctx) => {
-				const processor = new CardProcessor();
-				processor.renderFormCodeBlock(code, el, ctx, this.app);
-				if (el.parentElement) {
-					mountEditButtonToCodeblock(
-						this.app,
-						code,
-						el.parentElement
-					);
-				}
-			}
-		);
+		// this.registerMarkdownCodeBlockProcessor(
+		// 	"ntoc-card",
+		// 	async (code, el, ctx) => {
+		// 		const processor = new CardProcessor();
+		// 		processor.renderFormCodeBlock(code, el, ctx, this.app);
+		// 		if (el.parentElement) {
+		// 			mountEditButtonToCodeblock(
+		// 				this.app,
+		// 				code,
+		// 				el.parentElement
+		// 			);
+		// 		}
+		// 	}
+		// );
 	}
 
 	private setupScrollListener() {


### PR DESCRIPTION
将与“卡片”（Card）相关的功能和导入大部分注释掉，保留核心插件初始化与滚动/导航逻辑。
主要变更：
- 注释掉 CardCreateModal、CardProcessor、mountEditButtonToCodeblock 等模块的导入，减少启动时依赖。
- 注释掉注册 CodeMirror 光标扩展、插入阅读时间卡片与目录卡片的命令、
  以及在编辑器右键菜单中添加卡片项的注册逻辑，从而临时禁用这些交互。
- 注释掉 markdown code block 处理器的注册，避免在渲染 ntoc-card
  代码块时调用已注释的卡片渲染逻辑。

为什么这样做：
- 臨時移除/隔离卡片相关逻辑以便进行重构、调试或分阶段恢复，降低运行时错误风险，
  并便于在后续提交中逐步重构或替换卡片实现。