### PR TITLE
style(css): 移除多余的 z-index 以简化层级

### DIFF
--- a/src/components/toc-return-tools/TocReturnTools.css
+++ b/src/components/toc-return-tools/TocReturnTools.css
@@ -30,7 +30,6 @@
 	border: 1px solid var(--background-modifier-border);
 	cursor: pointer;
 	position: relative;
-	z-index: 1002;
 	outline: none;
 	backdrop-filter: blur(10px);
 	transition: all 0.2s ease;
@@ -45,7 +44,6 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	z-index: 1001;
 	animation: slideIn 0.3s ease;
 }
 


### PR DESCRIPTION
从 TocReturnTools.css 中删除两个冗余的 z-index 声明，
以减少样式层级冲突的风险并避免不必要的定位优先级。
这些修改不会改变视觉布局，而是降低与其他组件
在叠放上下文中发生冲突的可能性，提升样式可维护性。