### PR TITLE
fix(settings):统一 JSX 属性中 icon 的写法

### DIFF
--- a/src/settings/NTocSettings.tsx
+++ b/src/settings/NTocSettings.tsx
@@ -256,7 +256,7 @@ export const NTocSettings: FC = () => {
 										}}
 									/>
 									<ObsidianSetting.ExtraButton
-										icon="reset"
+										icon={"reset"}
 										onClick={() => {
 											settingsStore.updateSettingByPath(
 												"tool.returnToCursor.icon",
@@ -300,7 +300,7 @@ export const NTocSettings: FC = () => {
 										}}
 									/>
 									<ObsidianSetting.ExtraButton
-										icon="reset"
+										icon={"reset"}
 										onClick={() => {
 											settingsStore.updateSettingByPath(
 												"tool.returnToTop.icon",
@@ -342,7 +342,7 @@ export const NTocSettings: FC = () => {
 										}}
 									/>
 									<ObsidianSetting.ExtraButton
-										icon="reset"
+										icon={"reset"}
 										onClick={() => {
 											settingsStore.updateSettingByPath(
 												"tool.returnToBottom.icon",
@@ -387,7 +387,7 @@ export const NTocSettings: FC = () => {
 										}}
 									/>
 									<ObsidianSetting.ExtraButton
-										icon="reset"
+										icon={"reset"}
 										onClick={() => {
 											settingsStore.updateSettingByPath(
 												"tool.jumpToNextHeading.icon",
@@ -432,7 +432,7 @@ export const NTocSettings: FC = () => {
 										}}
 									/>
 									<ObsidianSetting.ExtraButton
-										icon="reset"
+										icon={"reset"}
 										onClick={() => {
 											settingsStore.updateSettingByPath(
 												"tool.jumpToPrevHeading.icon",


### PR DESCRIPTION
将多个 ObsidianSetting.ExtraButton 的 icon 属性从简写字符串
icon="reset" 修改为显式的花括号写法 icon={"reset"}。主要为了解决
JSX 属性类型一致性和格式化工具可能对不同写法的解析差异，提升代码
风格统一性并减少类型检查或 lint 报错的可能性。涉及返回光标、
返回顶部、返回底部、跳转到下一/上一标题等按钮的设置项。