### PR TITLE
feat(settings): 添加“导航按钮组”设置分组

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -57,6 +57,9 @@ const translations: BaseMessage = {
 		},
 		tool: {
 			name: "Tool",
+			headings: {
+				returnButtons: "Navigation button group",
+			},
 			useToolbar: {
 				name: "Use toolbar",
 				desc: "Show the toolbar with navigation buttons",

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -56,6 +56,9 @@ const translations: BaseMessage = {
 		},
 		tool: {
 			name: "工具",
+			headings: {
+				returnButtons: "導航按鈕組",
+			},
 			useToolbar: {
 				name: "使用工具列",
 				desc: "顯示帶有導覽按鈕的工具列",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -56,6 +56,9 @@ const translations: BaseMessage = {
 		},
 		tool: {
 			name: "工具",
+			headings: {
+				returnButtons: "导航按钮组",
+			},
 			useToolbar: {
 				name: "使用工具栏",
 				desc: "显示带有导航按钮的工具栏",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -49,6 +49,9 @@ export type BaseMessage = {
 		};
 		tool: {
 			name: string;
+			headings: {
+				returnButtons: string;
+			};
 			useToolbar: IBaseSettingsItem;
 			showProgressBar: IBaseSettingsItem;
 			showProgressCircle: IBaseSettingsItem;

--- a/src/settings/NTocSettings.tsx
+++ b/src/settings/NTocSettings.tsx
@@ -240,6 +240,13 @@ export const NTocSettings: FC = () => {
 
 					<ObsidianSetting
 						slots={{
+							name: t("settings.tool.headings.returnButtons"),
+						}}
+						heading={true}
+					/>
+
+					<ObsidianSetting
+						slots={{
 							name: t("settings.tool.returnToCursor.name"),
 							desc: t("settings.tool.returnToCursor.desc"),
 							control: (


### PR DESCRIPTION
在设置界面中添加一个分组标题“导航按钮组”，并在工具
设置（tool）下为多语言资源补充相应键（zh、zh-TW、en）与
类型定义。主要目的是把与“返回到光标/导航按钮”相关的选项
在 UI 中分组展示，提升设置的可读性与组织性。