### PR TITLE
feat: 引入 Markdown 渲染服务并在目录项中使用

### DIFF
--- a/src/services/MarkdownRenderService.ts
+++ b/src/services/MarkdownRenderService.ts
@@ -1,0 +1,72 @@
+import { App, Component, MarkdownRenderer } from "obsidian";
+
+/**
+ * Markdown 渲染服务
+ * 提供安全的 Markdown 渲染功能，避免在组件中直接使用插件实例
+ */
+export class MarkdownRenderService {
+	private app: App;
+	private component: Component;
+
+	constructor(app: App, component: Component) {
+		this.app = app;
+		this.component = component;
+	}
+
+	/**
+	 * 渲染 Markdown 内容到指定的 DOM 元素
+	 * @param content - 要渲染的 Markdown 内容
+	 * @param element - 目标 DOM 元素
+	 * @param sourcePath - 源文件路径，用于解析相对链接
+	 */
+	async renderMarkdown(
+		content: string,
+		element: HTMLElement,
+		sourcePath = ""
+	): Promise<void> {
+		try {
+			await MarkdownRenderer.render(
+				this.app,
+				content,
+				element,
+				sourcePath,
+				this.component
+			);
+		} catch (error) {
+			console.error("Failed to render markdown:", error);
+			// 如果渲染失败，回退到纯文本
+			element.textContent = content;
+		}
+	}
+
+	/**
+	 * 清理元素内容
+	 * @param element - 要清理的 DOM 元素
+	 */
+	clearElement(element: HTMLElement): void {
+		element.replaceChildren();
+		element.classList.remove("markdown-rendered");
+	}
+
+	/**
+	 * 设置纯文本内容
+	 * @param content - 文本内容
+	 * @param element - 目标 DOM 元素
+	 */
+	setTextContent(content: string, element: HTMLElement): void {
+		element.textContent = content;
+	}
+}
+
+/**
+ * 创建 Markdown 渲染服务的工厂函数
+ * @param app - Obsidian App 实例
+ * @param component - 组件实例，用于生命周期管理
+ * @returns MarkdownRenderService 实例
+ */
+export function createMarkdownRenderService(
+	app: App,
+	component: Component
+): MarkdownRenderService {
+	return new MarkdownRenderService(app, component);
+}

--- a/src/settings/SettingsStore.ts
+++ b/src/settings/SettingsStore.ts
@@ -1,5 +1,10 @@
 import NTocPlugin from "@src/main";
+import {
+	createMarkdownRenderService,
+	MarkdownRenderService,
+} from "@src/services/MarkdownRenderService";
 import { DEFAULT_SETTINGS, NTocPluginSettings } from "@src/types/types";
+import { Component } from "obsidian";
 
 export default class SettingsStore {
 	#plugin: NTocPlugin;
@@ -24,12 +29,17 @@ export default class SettingsStore {
 		return Object.assign({}, this.#store);
 	}
 
-	get plugin() {
-		return this.#plugin;
-	}
-
 	get app() {
 		return this.#plugin.app;
+	}
+
+	/**
+	 * 创建 Markdown 渲染服务
+	 * @param component - 组件实例，用于管理渲染生命周期
+	 * @returns MarkdownRenderService 实例
+	 */
+	createMarkdownRenderService(component: Component): MarkdownRenderService {
+		return createMarkdownRenderService(this.app, component);
 	}
 
 	#notifyStoreSubscribers() {


### PR DESCRIPTION
- 添加独的 MarkdownRenderService，用于安全、可复用的 Markdown 渲染，提供 render、clearElement、setTextContent方法，并导出 createMarkdownRenderService 工函数。
- 在 SettingsStore 中新增 createMarkdownRenderService 工厂方法，允许在组件内通过 store 创建并管理渲染服务的生命周期。
- 在 TocItem 组件中用 useMemo 创建临时 Component 实例并通过 store 获取渲染服务，替换原有直接调用全局 MarkdownRenderer 的逻辑。
- 在 TocItem 卸载时调用 Component.unload 清理资源，避免内存泄漏。