### PR TITLE
refactor: 重命名并统一 ObsidianSetting 组件变量

### DIFF
--- a/src/settings/ObsidianSetting.tsx
+++ b/src/settings/ObsidianSetting.tsx
@@ -497,20 +497,20 @@ type ObsidianSettingWithComponents = FC<ObsidianSettingProps> & {
 };
 
 // 将ObsidianSetting转换为带有子组件的类型
-const ObsidianSettingWithComponents =
+const ObsidianSettingComponent =
 	ObsidianSetting as ObsidianSettingWithComponents;
 
 // 将子组件作为ObsidianSetting的静态属性
-ObsidianSettingWithComponents.Button = Button;
-ObsidianSettingWithComponents.Dropdown = Dropdown;
-ObsidianSettingWithComponents.ExtraButton = ExtraButton;
-ObsidianSettingWithComponents.Container = Container;
-ObsidianSettingWithComponents.MomentFormat = MomentFormat;
-ObsidianSettingWithComponents.Text = Text;
-ObsidianSettingWithComponents.Toggle = Toggle;
+ObsidianSettingComponent.Button = Button;
+ObsidianSettingComponent.Dropdown = Dropdown;
+ObsidianSettingComponent.ExtraButton = ExtraButton;
+ObsidianSettingComponent.Container = Container;
+ObsidianSettingComponent.MomentFormat = MomentFormat;
+ObsidianSettingComponent.Text = Text;
+ObsidianSettingComponent.Toggle = Toggle;
 
 // 重新导出ObsidianSetting（现在包含所有子组件作为静态属性）
-export default ObsidianSettingWithComponents;
+export default ObsidianSettingComponent;
 
 // 同时导出ObsidianSetting本身，以便可以直接使用
 export { ObsidianSetting };


### PR DESCRIPTION
将 ObsidianSettingWithComponents 重命名为 ObsidianSettingComponent，
并相应更新静态子组件的赋值与默认导出。主要改动是统一变量
命名以提高可读性并避免歧义，使组件命名更简洁一致。此修改不
影响外部 API（仍导出 ObsidianSetting），但改善了内部代码的语义
清晰度，便于后续维护与扩展。