### PR TITLE
feat: 为 TOC 工具添加国际化文案

### DIFF
--- a/src/components/progress-circle/ProgressCircle.tsx
+++ b/src/components/progress-circle/ProgressCircle.tsx
@@ -1,5 +1,5 @@
 import { FC } from "react";
-import { CircularProgressbar, buildStyles } from "react-circular-progressbar";
+import { buildStyles, CircularProgressbar } from "react-circular-progressbar";
 import "react-circular-progressbar/dist/styles.css";
 import "./ProgressCircle.css";
 

--- a/src/components/toc-return-tools/TocReturnTools.tsx
+++ b/src/components/toc-return-tools/TocReturnTools.tsx
@@ -1,5 +1,7 @@
 import usePluginSettings from "@src/hooks/usePluginSettings";
 import useSettingsStore from "@src/hooks/useSettingsStore";
+import { t } from "@src/i18n/i18n";
+import { TranslationKeys } from "@src/i18n/types";
 import {
 	isSourceMode,
 	navigateHeading,
@@ -107,6 +109,7 @@ export const TocReturnTools: FC<TocReturnToolsProps> = ({
 							? "NToc__tool-expand-right"
 							: "NToc__tool-expand-left"
 					}`}
+					aria-label={t("tools.returnNavigation")}
 				>
 					{enabledTools.map((tool) => {
 						return (
@@ -117,6 +120,9 @@ export const TocReturnTools: FC<TocReturnToolsProps> = ({
 								}}
 								className="NToc__tool-button"
 								onClick={() => handleToolClick(tool.key)}
+								aria-label={t(
+									`tools.${tool.key}` as TranslationKeys
+								)}
 							></button>
 						);
 					})}

--- a/src/components/toc-toolbar/TocToolbar.tsx
+++ b/src/components/toc-toolbar/TocToolbar.tsx
@@ -1,5 +1,6 @@
 import usePluginSettings from "@src/hooks/usePluginSettings";
 import useSettingsStore from "@src/hooks/useSettingsStore";
+import { t } from "@src/i18n/i18n";
 import cleanHeading from "@src/utils/cleanHeading";
 import {
 	ArrowLeftRight,
@@ -69,7 +70,7 @@ export const TocToolbar: FC<TocToolbarProps> = ({
 				className={`NToc__toc-toolbar-button  ${
 					settings.toc.alwaysExpand ? "active" : ""
 				}`}
-				aria-label="Pin TOC group"
+				aria-label={t("tools.pinTOC")}
 				onClick={() => {
 					settingsStore.updateSettingByPath(
 						"toc.alwaysExpand",
@@ -83,7 +84,7 @@ export const TocToolbar: FC<TocToolbarProps> = ({
 			</button>
 			<button
 				className="NToc__toc-toolbar-button"
-				aria-label="Change TOC group position"
+				aria-label={t("tools.changePosition")}
 				onClick={() => {
 					settingsStore.updateSettingByPath(
 						"toc.position",
@@ -97,7 +98,7 @@ export const TocToolbar: FC<TocToolbarProps> = ({
 			</button>
 			<button
 				className="NToc__toc-toolbar-button"
-				aria-label="Expand/Collapse TOC items"
+				aria-label={t("tools.expandCollapse")}
 				onClick={hasAnyCollapsed ? onExpandAll : onCollapseAll}
 			>
 				<span className="NToc__toc-toolbar-button-icon">
@@ -110,7 +111,7 @@ export const TocToolbar: FC<TocToolbarProps> = ({
 			</button>
 			<button
 				className="NToc__toc-toolbar-button"
-				aria-label="Add offset to the left"
+				aria-label={t("tools.leftOffset")}
 				onClick={() => handleOffsetChange("left")}
 			>
 				<span className="NToc__toc-toolbar-button-icon">
@@ -119,7 +120,7 @@ export const TocToolbar: FC<TocToolbarProps> = ({
 			</button>
 			<button
 				className="NToc__toc-toolbar-button"
-				aria-label="Add offset to the right"
+				aria-label={t("tools.rightOffset")}
 				onClick={() => handleOffsetChange("right")}
 			>
 				<span className="NToc__toc-toolbar-button-icon">
@@ -128,7 +129,7 @@ export const TocToolbar: FC<TocToolbarProps> = ({
 			</button>
 			<button
 				className="NToc__toc-toolbar-button"
-				aria-label="Copy TOC to clipboard"
+				aria-label={t("tools.copyTOC")}
 				onClick={handleCopyToClipboard}
 			>
 				<span className="NToc__toc-toolbar-button-icon">

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -128,6 +128,20 @@ const translations: BaseMessage = {
 			noneCustomProperty: "No custom properties defined for ",
 		},
 	},
+	tools: {
+		pinTOC: "Pin/Unpin TOC",
+		changePosition: "Change TOC position",
+		expandCollapse: "Expand/Collapse TOC items",
+		leftOffset: "Add offset to the left",
+		rightOffset: "Add offset to the right",
+		copyTOC: "Copy TOC to clipboard",
+		returnNavigation: "Return navigation",
+		returnToCursor: "To cursor",
+		returnToTop: "To top",
+		returnToBottom: "To bottom",
+		jumpToNextHeading: "Next heading",
+		jumpToPrevHeading: "Previous heading",
+	},
 };
 
 export default translations;

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -127,6 +127,20 @@ const translations: BaseMessage = {
 			noneCustomProperty: "尚未定義自訂屬性",
 		},
 	},
+	tools: {
+		pinTOC: "固定／取消固定目錄",
+		changePosition: "更改目錄位置",
+		expandCollapse: "展開／收合目錄項目",
+		leftOffset: "向左偏移",
+		rightOffset: "向右偏移",
+		copyTOC: "複製目錄到剪貼簿",
+		returnNavigation: "返回導航",
+		returnToCursor: "返回游標位置",
+		returnToTop: "返回頂部",
+		returnToBottom: "返回底部",
+		jumpToNextHeading: "下一个标题",
+		jumpToPrevHeading: "上一个标题",
+	},
 };
 
 export default translations;

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -127,6 +127,20 @@ const translations: BaseMessage = {
 			noneCustomProperty: "未定义自定义属性",
 		},
 	},
+	tools: {
+		pinTOC: "固定/取消固定目录",
+		changePosition: "更改目录位置",
+		expandCollapse: "展开/收起目录项",
+		leftOffset: "向左偏移",
+		rightOffset: "向右偏移",
+		copyTOC: "复制目录到剪贴板",
+		returnNavigation: "返回导航",
+		returnToCursor: "返回光标位置",
+		returnToTop: "返回顶部",
+		returnToBottom: "返回底部",
+		jumpToNextHeading: "下一个标题",
+		jumpToPrevHeading: "上一个标题",
+	},
 };
 
 export default translations;

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -96,6 +96,20 @@ export type BaseMessage = {
 			noneCustomProperty: string;
 		};
 	};
+	tools: {
+		pinTOC: string;
+		changePosition: string;
+		expandCollapse: string;
+		leftOffset: string;
+		rightOffset: string;
+		copyTOC: string;
+		returnNavigation: string;
+		returnToCursor: string;
+		returnToTop: string;
+		returnToBottom: string;
+		jumpToNextHeading: string;
+		jumpToPrevHeading: string;
+	};
 };
 
 // 生成所有可能的翻译键路径类型


### PR DESCRIPTION
- 在 TocToolbar 和 TocReturnTools 组件中引入并使用 t()
  翻译函数，替换原先静态的 aria-label 字符串，确保无障碍
  文案支持多语言。
- 在 i18n 本地化文件（en, zh-TW, zh）中新增 tools 字段，
  提供 TOC 操作（固定/取消固定、改变位置、展开/收起、左右
  偏移、复制目录、返回导航/光标/顶部/底部、跳到上下标题等）
  的英文、繁体、简体翻译。
- 在类型定义 i18n/types.ts 中添加 tools 类型，确保类型安全
  和翻译键的正确性。

为什么做这些改动
- 提升可访问性和国际化支持，aria-label 现在会根据当前语
  言动态显示，便于不同语言用户及屏幕阅读器使用。
- 通过统一的翻译键和类型定义，减少硬编码字符串、便于后
  续维护与扩展语言。