### PR TITLE
fix: 支持跳过一级标题并修正依赖

### DIFF
--- a/src/components/toc-navigator/TocNavigator.tsx
+++ b/src/components/toc-navigator/TocNavigator.tsx
@@ -264,6 +264,13 @@ export const TocNavigator: FC<TocNavigatorProps> = ({
 		const collapsedLevels: number[] = [];
 		for (let i = 0; i < headings.length; i++) {
 			const level = headings[i].level;
+			
+			// 如果开启了 skipHeading1 且当前是一级标题，则隐藏
+			if (settings.render.skipHeading1 && level === 1) {
+				result[i] = false;
+				continue;
+			}
+			
 			// 离开较深的折叠子树：弹出所有 >= 当前层级的折叠层级
 			while (
 				collapsedLevels.length > 0 &&
@@ -279,7 +286,7 @@ export const TocNavigator: FC<TocNavigatorProps> = ({
 			}
 		}
 		return result;
-	}, [headings, collapsedSet]);
+	}, [headings, collapsedSet, settings.render.skipHeading1]);
 
 	const shouldShowToc = useMemo(() => {
 		if (settings.render.skipHeading1) {


### PR DESCRIPTION
在 TocNavigator 中加入对.render.skipHeading1 的处理，
当该设置开启且当前条目为一级标题（level === 1）时将其隐藏。
为避免渲染一致性问题，同时将该设置加入 useMemo 的依赖列表。

这样可以在目录中按配置跳过一级标题，修正因未包含设置依赖
导致的状态不同步问题，提高渲染正确性和可配置性。