### PR TITLE
docs: 更新安装和许可

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -11,13 +11,13 @@
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/RavenHogWarts/obsidian-next-toc?style=flat&label=最后提交)](https://github.com/RavenHogWarts/obsidian-next-toc/commits/master)
 
 ## 安装
-### 社区插件市场安装
+<!-- ### 社区插件市场安装
 
 [点击安装](obsidian://show-plugin?id=next-toc)，或按以下步骤操作：
 
 1. 打开 Obsidian 并前往 `设置 > 第三方插件`。
-2. 搜索 “Yet Another TOC”。
-3. 点击 “安装”。
+2. 搜索 “Next TOC”。
+3. 点击 “安装”。 -->
 
 ### 手动安装
 
@@ -55,7 +55,7 @@
 
 ## 许可证
 
-此项目基于 xxx LICENSE 许可 - 详情请参阅 [LICENSE](LICENSE) 文件。
+此项目基于 GPL-3.0 LICENSE 许可 - 详情请参阅 [LICENSE](LICENSE) 文件。
 
 ## Star 历史
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you find this plugin helpful, you can support the development through:
 
 ## License
 
-This project is licensed under the xxx LICENSE - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the GPL-3.0 LICENSE - see the [LICENSE](LICENSE) file for details.
 
 ## Star History
 


### PR DESCRIPTION
更新中文英文 README 中的安装说明和信息。
主要改动：
- 暂时注释掉社区插件市场的安装指引，并把示例插件名称从
  “Yet Another TOC” 改为 “Next TOC”，以避免误导用户或在市场名
  称变更时造成混淆。
- 将项目许可证文本从占位符 “xxx LICENSE” 明确为 GPL-3.0，
  同步更新 README-zh.md 与 README.md，确保许可证信息一致
  且准确。

这样做的原因是修正文档中的不准确信息，提升用户引导的准确
性并保证开源许可证声明的一致性与合规性。