### PR TITLE
feat: 启用 CM6 光标监听扩展

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import {
 	updateNTocRender,
 } from "./components/toc-navigator/NTocRender";
 import { t } from "./i18n/i18n";
+import { createCursorListenerExtension } from "./services/cursorListenerExtension";
 import { PluginSettingTab } from "./settings/PluginSettingTab";
 import SettingsStore from "./settings/SettingsStore";
 import { NTocPluginSettings } from "./types/types";
@@ -35,7 +36,7 @@ export default class NTocPlugin extends Plugin {
 		this.registerCodeblockProcessor();
 
 		// Register CM6 cursor listener extension
-		// this.registerEditorExtension(createCursorListenerExtension(this));
+		this.registerEditorExtension(createCursorListenerExtension(this));
 
 		// Setup initial scroll listener
 		this.setupScrollListener();


### PR DESCRIPTION
在主入口注册并启用 createCursorListenerExtension，使编辑器
能够使用基于6 的光标监听器。之前该展仅作为注释
示例存在，现在实际注册以支持插件对光标位置的实时追踪
和相关功能（例如同步高亮或导航联动）。这种变更提升了
编辑器扩展的即时交互能力并为后续功能扩展奠定基础。