### PR TITLE
chore(funding): 添加自定义资助链接

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: ["https://afdian.com/a/ravenhogwarts"]


### PR DESCRIPTION
在仓库根目录新增 .github/FUNDING.yml 文件，加入自定义
的资助地址（afdian）。这样可以在 GitHub 页面显示该资助
选项，便于用户直接访问并支持项目。