### PR TITLE
refactor: 移除悬浮目录的黑名单功能

### DIFF
--- a/src/components/toc-navigator/TocNavigator.tsx
+++ b/src/components/toc-navigator/TocNavigator.tsx
@@ -2,10 +2,7 @@ import usePluginSettings from "@src/hooks/usePluginSettings";
 import { useScrollProgress } from "@src/hooks/useScrollProgress";
 import useSettingsStore from "@src/hooks/useSettingsStore";
 import calculateActualDepth from "@src/utils/calculateActualDepth";
-import {
-	shouldShowToc as checkShouldShowToc,
-	shouldUseHeadingNumber as checkShouldUseHeadingNumber,
-} from "@src/utils/checkBlacklist";
+import { shouldUseHeadingNumber as checkShouldUseHeadingNumber } from "@src/utils/checkBlacklist";
 import hasChildren from "@src/utils/hasChildren";
 import smoothScroll from "@src/utils/smoothScroll";
 import { HeadingCache, MarkdownView } from "obsidian";
@@ -41,15 +38,7 @@ export const TocNavigator: FC<TocNavigatorProps> = ({
 
 	// Calculate the effective settings based on blacklist
 	const currentFile = currentView.file;
-	const effectiveShowToc = useMemo(
-		() =>
-			checkShouldShowToc(
-				settings.toc.show,
-				currentFile,
-				settings.toc.hideBlacklist
-			),
-		[settings.toc.show, currentFile, settings.toc.hideBlacklist]
-	);
+	const effectiveShowToc = settings.toc.show;
 
 	const effectiveUseHeadingNumber = useMemo(
 		() =>

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -11,10 +11,6 @@ const translations: BaseMessage = {
 		tocExpand: "Expand/Collapse TOC",
 		insertReadingTimeCard: "Insert reading time card",
 		insertTableOfContentsCard: "Insert table of contents card",
-		addCurrentFileToHideTocBlacklist:
-			"Toggle current file in TOC blacklist",
-		addCurrentFolderToHideTocBlacklist:
-			"Toggle current folder in TOC blacklist",
 		addCurrentFileToHideHeadingNumberBlacklist:
 			"Toggle current file in heading number blacklist",
 		addCurrentFolderToHideHeadingNumberBlacklist:
@@ -56,10 +52,6 @@ const translations: BaseMessage = {
 			offset: {
 				name: "TOC offset",
 				desc: "Set the offset of the table of contents",
-			},
-			hideBlacklist: {
-				name: "TOC blacklist",
-				desc: "Specify files that should hide the TOC (one path per line). Supports wildcards: * (any characters), ? (single character). Only works when 'TOC show' is enabled. Example: folder/file.md or *.md",
 			},
 		},
 		render: {

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -10,9 +10,6 @@ const translations: BaseMessage = {
 		tocExpand: "展開／收合目錄",
 		insertReadingTimeCard: "插入閱讀時間卡片",
 		insertTableOfContentsCard: "插入目錄卡片",
-		addCurrentFileToHideTocBlacklist: "新增/移除目前檔案至懸浮目錄黑名單",
-		addCurrentFolderToHideTocBlacklist:
-			"新增/移除目前資料夾至懸浮目錄黑名單",
 		addCurrentFileToHideHeadingNumberBlacklist:
 			"新增/移除目前檔案至標題編號黑名單",
 		addCurrentFolderToHideHeadingNumberBlacklist:
@@ -52,10 +49,6 @@ const translations: BaseMessage = {
 			offset: {
 				name: "目錄偏移",
 				desc: "設定目錄的偏移量",
-			},
-			hideBlacklist: {
-				name: "懸浮目錄黑名單",
-				desc: "指定需要隱藏目錄的檔案（每行一個路徑）。支援萬用字元：* (任意字元)，? (單一字元)。僅在「顯示目錄」開啟時生效。範例：folder/file.md 或 *.md",
 			},
 		},
 		render: {

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -10,9 +10,6 @@ const translations: BaseMessage = {
 		tocExpand: "展开/收起目录",
 		insertReadingTimeCard: "插入阅读时间卡片",
 		insertTableOfContentsCard: "插入目录卡片",
-		addCurrentFileToHideTocBlacklist: "添加/移除当前文件到悬浮目录黑名单",
-		addCurrentFolderToHideTocBlacklist:
-			"添加/移除当前文件夹到悬浮目录黑名单",
 		addCurrentFileToHideHeadingNumberBlacklist:
 			"添加/移除当前文件到标题编号黑名单",
 		addCurrentFolderToHideHeadingNumberBlacklist:
@@ -52,10 +49,6 @@ const translations: BaseMessage = {
 			offset: {
 				name: "目录偏移",
 				desc: "设置目录的偏移量",
-			},
-			hideBlacklist: {
-				name: "悬浮目录黑名单",
-				desc: "指定需要隐藏目录的文件（每行一个路径）。支持通配符：* (任意字符)，? (单个字符)。仅在「显示目录」开启时生效。示例：folder/file.md 或 *.md",
 			},
 		},
 		render: {

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -26,8 +26,6 @@ export type BaseMessage = {
 		tocExpand: string;
 		insertReadingTimeCard: string;
 		insertTableOfContentsCard: string;
-		addCurrentFileToHideTocBlacklist: string;
-		addCurrentFolderToHideTocBlacklist: string;
 		addCurrentFileToHideHeadingNumberBlacklist: string;
 		addCurrentFolderToHideHeadingNumberBlacklist: string;
 	};
@@ -52,7 +50,6 @@ export type BaseMessage = {
 				};
 			}>;
 			offset: IBaseSettingsItem;
-			hideBlacklist: IBaseSettingsItem;
 		};
 		render: {
 			name: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -149,54 +149,6 @@ export default class NTocPlugin extends Plugin {
 			},
 		});
 
-		// Toggle current file in hide TOC blacklist
-		this.addCommand({
-			id: "add-current-file-to-hide-toc-blacklist",
-			name: t("commands.addCurrentFileToHideTocBlacklist"),
-			callback: () => {
-				const file = this.app.workspace.getActiveFile();
-				if (!file) {
-					return;
-				}
-
-				const newBlacklist = toggleFileInBlacklist(
-					file,
-					this.settingsStore.settings.toc.hideBlacklist
-				);
-
-				if (newBlacklist) {
-					this.settingsStore.updateSettingByPath(
-						"toc.hideBlacklist",
-						newBlacklist
-					);
-				}
-			},
-		});
-
-		// Toggle current folder in hide TOC blacklist
-		this.addCommand({
-			id: "add-current-folder-to-hide-toc-blacklist",
-			name: t("commands.addCurrentFolderToHideTocBlacklist"),
-			callback: () => {
-				const file = this.app.workspace.getActiveFile();
-				if (!file) {
-					return;
-				}
-
-				const newBlacklist = toggleFolderInBlacklist(
-					file,
-					this.settingsStore.settings.toc.hideBlacklist
-				);
-
-				if (newBlacklist) {
-					this.settingsStore.updateSettingByPath(
-						"toc.hideBlacklist",
-						newBlacklist
-					);
-				}
-			},
-		});
-
 		// Toggle current file in hide heading number blacklist
 		this.addCommand({
 			id: "add-current-file-to-hide-heading-number-blacklist",

--- a/src/settings/tabs/TocTabContent.tsx
+++ b/src/settings/tabs/TocTabContent.tsx
@@ -111,29 +111,6 @@ export const TocTabContent: FC = () => {
 					),
 				}}
 			/>
-
-			<ObsidianSetting
-				visible={settings.toc.show}
-				slots={{
-					name: t("settings.toc.hideBlacklist.name"),
-					desc: t("settings.toc.hideBlacklist.desc"),
-					control: (
-						<ObsidianSetting.TextArea
-							value={settings.toc.hideBlacklist.join("\n")}
-							onChange={(value) => {
-								const list = value
-									.split("\n")
-									.map((line) => line.trim())
-									.filter((line) => line.length > 0);
-								settingsStore.updateSettingByPath(
-									"toc.hideBlacklist",
-									list
-								);
-							}}
-						/>
-					),
-				}}
-			/>
 		</ObsidianSetting.Container>
 	);
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -12,7 +12,6 @@ export interface NTocPluginSettings {
 		width: number;
 		position: NTocPosition;
 		offset: number;
-		hideBlacklist: string[]; // Files that should hide TOC (only works when show is true)
 	};
 	render: {
 		useHeadingNumber: boolean;
@@ -40,7 +39,6 @@ export const DEFAULT_SETTINGS: NTocPluginSettings = {
 		width: 240,
 		position: "right",
 		offset: 12,
-		hideBlacklist: [],
 	},
 	render: {
 		useHeadingNumber: false,

--- a/src/utils/checkBlacklist.ts
+++ b/src/utils/checkBlacklist.ts
@@ -36,33 +36,6 @@ export function isFileInBlacklist(
 }
 
 /**
- * Get the final value for whether to show TOC based on settings and blacklist
- * Only checks blacklist when show is true
- * @param defaultShow - The default show setting value
- * @param file - The current file
- * @param hideBlacklist - Files that should hide TOC
- * @returns true if TOC should be shown
- */
-export function shouldShowToc(
-	defaultShow: boolean,
-	file: TFile | null,
-	hideBlacklist: string[]
-): boolean {
-	// If show is disabled, always return false
-	if (!defaultShow) {
-		return false;
-	}
-
-	// If show is enabled, check if file is in blacklist
-	if (isFileInBlacklist(file, hideBlacklist)) {
-		return false;
-	}
-
-	// Otherwise show TOC
-	return true;
-}
-
-/**
  * Get the final value for whether to use heading numbers based on settings and blacklist
  * Only checks blacklist when useHeadingNumber is true
  * @param defaultUseHeadingNumber - The default useHeadingNumber setting value


### PR DESCRIPTION
移除与“隐藏悬浮目录 (hide TOC) 黑名单”相关的 UI、文案和命令实现。
删除了 i18n 中英中对应的文本、设置面板里的黑名单输入项、类型定义中的
hideBlacklist 字段，以及主模块中用于切换文件/文件夹到黑名单的命令。
同时简化了 TocNavigator 中对是否显示目录的判断，直接使用设置中
toc.show，去除对 hideBlacklist 的检查。

这样做是因为不再需要按黑名单条件动态隐藏悬浮目录，简化了设置与代码
路径，减少维护成本并避免不必要的复杂性。