### PR TITLE
refactor: 移除重复的黑名单判断并直接使用设置值

### DIFF
--- a/src/components/toc-navigator/TocNavigator.tsx
+++ b/src/components/toc-navigator/TocNavigator.tsx
@@ -2,7 +2,6 @@ import usePluginSettings from "@src/hooks/usePluginSettings";
 import { useScrollProgress } from "@src/hooks/useScrollProgress";
 import useSettingsStore from "@src/hooks/useSettingsStore";
 import calculateActualDepth from "@src/utils/calculateActualDepth";
-import { shouldUseHeadingNumber as checkShouldUseHeadingNumber } from "@src/utils/checkBlacklist";
 import hasChildren from "@src/utils/hasChildren";
 import smoothScroll from "@src/utils/smoothScroll";
 import { HeadingCache, MarkdownView } from "obsidian";
@@ -36,23 +35,6 @@ export const TocNavigator: FC<TocNavigatorProps> = ({
 	const settingsStore = useSettingsStore();
 	const settings = usePluginSettings(settingsStore);
 
-	// Calculate the effective settings based on blacklist
-	const currentFile = currentView.file;
-	const effectiveShowToc = settings.toc.show;
-
-	const effectiveUseHeadingNumber = useMemo(
-		() =>
-			checkShouldUseHeadingNumber(
-				settings.render.useHeadingNumber,
-				currentFile,
-				settings.render.hideHeadingNumberBlacklist
-			),
-		[
-			settings.render.useHeadingNumber,
-			currentFile,
-			settings.render.hideHeadingNumberBlacklist,
-		]
-	);
 	const NTocContainerRef = useRef<HTMLDivElement>(null);
 	const NTocGroupRef = useRef<HTMLDivElement>(null);
 	const NTocGroupIndicatorsRef = useRef<HTMLDivElement>(null);
@@ -93,7 +75,7 @@ export const TocNavigator: FC<TocNavigatorProps> = ({
 	useEffect(() => {
 		if (NTocGroupRef.current) {
 			const group = NTocGroupRef.current;
-			if (effectiveShowToc === false) {
+			if (settings.toc.show === false) {
 				group.classList.add("NToc__group-hidden");
 				// 当隐藏TOC时，重置悬停状态
 				setIsHovered(false);
@@ -101,7 +83,7 @@ export const TocNavigator: FC<TocNavigatorProps> = ({
 				group.classList.remove("NToc__group-hidden");
 			}
 		}
-	}, [effectiveShowToc]);
+	}, [settings.toc.show]);
 
 	useEffect(() => {
 		if (NTocGroupContentRef.current) {


### PR DESCRIPTION
从 TocNavigator 中移除对 shouldUseHeadingNumber 的导入和基于
黑名单的计算逻辑，简化组件状态管理。原本通过
checkShouldUseHeadingNumber 及 useMemo 根据当前文件和黑名单
决定是否显示标题编号的逻辑被删去，改为组件内直接读取
settings.toc.show 及其他设置值作为依赖。

这样做的原因是减少复杂性和不必要的 memo 化，避免在
组件渲染时引入与文件黑名单相关的副作用，并确保对
settings 变更的响应更直接可靠。代码中相应的依赖项也
被更新为直接使用 settings 的字段。