### PR TITLE
fix: 修正目录面板器以匹新结构

### DIFF
--- a/src/components/toc-navigator/TocNavigator.css
+++ b/src/components/toc-navigator/TocNavigator.css
@@ -323,11 +323,11 @@
 }
 
 /* 特定页面控制样式 */
-.pin-ntoc ~ .NToc__view .NToc__container {
+.pin-ntoc ~ .NToc__view .NToc__group-content {
 	opacity: 1 !important;
 	visibility: visible !important;
 }
-.unpin-ntoc ~ .NToc__view .NToc__container {
+.unpin-ntoc ~ .NToc__view .NToc__group-content {
 	opacity: 0 !important;
 	visibility: hidden !important;
 }


### PR DESCRIPTION
将控显示/隐藏的选择器从 .NToc__container 更改为
.NToc__group-content，以匹配组件结构的更新。修复后可
确保在 .pin-ntoc 与 .unpin-ntoc 状态下，目录面板的
透明度与可见性样式正确应用，避免旧选择器导致的
样式失效或视觉异常。