### PR TITLE
fix(view): 避免自动激活并注释 revealLeaf 调用

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -72,12 +72,11 @@ export default class NTocPlugin extends Plugin {
 		if (this.app.workspace.getLeavesOfType(VIEW_TYPE_NTOC).length === 0) {
 			await this.app.workspace.getRightLeaf(false)?.setViewState({
 				type: VIEW_TYPE_NTOC,
-				active: true,
 			});
 		}
-		this.app.workspace.revealLeaf(
-			this.app.workspace.getLeavesOfType(VIEW_TYPE_NTOC)[0]
-		);
+		// this.app.workspace.revealLeaf(
+		// 	this.app.workspace.getLeavesOfType(VIEW_TYPE_NTOC)[0]
+		// );
 	}
 
 	private registerCommands() {


### PR DESCRIPTION
在打开自定义侧栏视图时取消对 leaf 的强制激活和可见性操作。
删除了 setViewState 的 active:true 设定，并将对 revealLeaf 的调用改为注释，
从而避免在侧栏已经存在时改变当前焦点或强制滚动到该 leaf。
这样做是为了减少对工作区焦点的干扰，提升用户在已打开视图时的可控性。