### PR TITLE
feat: 添加打开目录侧边视图命令，移除自启动

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -3,6 +3,7 @@ import { BaseMessage } from "../types";
 // Remember [use sentence case in UI](https://docs.obsidian.md/Plugins/Releasing/Plugin+guidelines#Use+sentence+case+in+UI)
 const translations: BaseMessage = {
 	commands: {
+		openTocView: "Open TOC view",
 		returnToCursor: "Return to cursor",
 		scrollToTop: "Scroll to top",
 		scrollToBottom: "Scroll to bottom",

--- a/src/i18n/locales/zh-TW.ts
+++ b/src/i18n/locales/zh-TW.ts
@@ -2,6 +2,7 @@ import { BaseMessage } from "../types";
 
 const translations: BaseMessage = {
 	commands: {
+		openTocView: "開啟目錄側邊視圖",
 		returnToCursor: "返回游標位置",
 		scrollToTop: "捲動到頂部",
 		scrollToBottom: "捲動到底部",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -2,6 +2,7 @@ import { BaseMessage } from "../types";
 
 const translations: BaseMessage = {
 	commands: {
+		openTocView: "打开目录侧边视图",
 		returnToCursor: "返回光标位置",
 		scrollToTop: "滚动到顶部",
 		scrollToBottom: "滚动到底部",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -18,6 +18,7 @@ type SettingsItem<T = Record<string, never>> = IBaseSettingsItem & T;
 // 定义翻译结构类型
 export type BaseMessage = {
 	commands: {
+		openTocView: string;
 		returnToCursor: string;
 		scrollToTop: string;
 		scrollToBottom: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,10 +41,6 @@ export default class NTocPlugin extends Plugin {
 		this.registerContextMenu();
 		this.registerCodeblockProcessor();
 
-		this.app.workspace.onLayoutReady(() => {
-			this.initLeaf();
-		});
-
 		// Register CM6 cursor listener extension
 		this.registerEditorExtension(createCursorListenerExtension(this));
 
@@ -74,12 +70,20 @@ export default class NTocPlugin extends Plugin {
 				type: VIEW_TYPE_NTOC,
 			});
 		}
-		// this.app.workspace.revealLeaf(
-		// 	this.app.workspace.getLeavesOfType(VIEW_TYPE_NTOC)[0]
-		// );
+		this.app.workspace.revealLeaf(
+			this.app.workspace.getLeavesOfType(VIEW_TYPE_NTOC)[0]
+		);
 	}
 
 	private registerCommands() {
+		this.addCommand({
+			id: "open-toc-view",
+			name: t("commands.openTocView"),
+			callback: async () => {
+				await this.initLeaf();
+			},
+		});
+
 		this.addCommand({
 			id: "return-to-cursor",
 			name: t("commands.returnToCursor"),


### PR DESCRIPTION
在 i18n 翻译文件中增加 openTocView 键，补
全英文、简体中文与繁体中文的文案，确保新命令
有对应的多语言字符串。

在 types.ts 中为翻译结构添加 openTocView 类型，
保证类型检查覆盖新键。

在 main.ts 中恢复并启用侧边面板初始化及显
示逻辑，添加 open-toc-view 命令，命令会调用
initLeaf 初始化并展示目录侧边视图。这样用户
可以通过命令打开 TOC 侧边栏，提升可发现性
和可用性。