### PR TITLE
feat: 为插件设置页添加图标字段

### DIFF
--- a/src/settings/PluginSettingTab.tsx
+++ b/src/settings/PluginSettingTab.tsx
@@ -8,6 +8,7 @@ import { NTocSettings } from "./NTocSettings";
 export class PluginSettingTab extends ObPluginSettingTab {
 	plugin: NTocPlugin;
 	root: Root;
+	icon: string = "table-of-contents";
 
 	constructor(plugin: NTocPlugin) {
 		super(plugin.app, plugin);


### PR DESCRIPTION
在 PluginSettingTab 类中新增了 icon 字段并初始化为
"table-of-contents"。这使得设置页能够携带默认图标，
便于后续在界面或主题中统一显示和修改图标。

主要原因是为插件设置页提供可配置的视觉标识，
为未来扩展（如用户自定义图标或主题适配）做好准备。