### PR TITLE
fix(icon-picker): 优化图标建议渲染逻辑

### DIFF
--- a/src/components/icon-picker/IconPicker.tsx
+++ b/src/components/icon-picker/IconPicker.tsx
@@ -73,7 +73,6 @@ class IconSelector extends FuzzySuggestModal<IconName> {
 	}
 
 	renderSuggestion(item: FuzzyMatch<IconName>, el: HTMLElement) {
-		super.renderSuggestion(item, el);
 		el.addClass("NToc__icon-suggestion");
 		setIcon(el, item.item);
 		el.createSpan({ text: item.item });


### PR DESCRIPTION
移除对基类 renderSuggestion 的调用，改为在子组件中
直接设置建议项的样式和内容。这样可以避免父类对 DOM
结构或样式的默认处理与当前组件需求冲突，确保每个
建议项都带有正确的类名和图标显示，并提高渲染可控性。