### PR TITLE
chore: 更新 package-lock 以同步依赖元数据

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,136 +7,228 @@ import globals from "globals";
 export default [
 	js.configs.recommended,
 	{
-		files: ["**/*.ts", "**/*.tsx"],
+		ignores: [
+			"main.js",
+			"*.config.mjs",
+			"node_modules/**",
+			"docs/**",
+			"scripts/**",
+			"*.js",
+			"test/**/*.ts",
+		],
+	},
+	{
+		files: ["main.ts", "src/**/*.ts", "src/**/*.tsx"],
 		languageOptions: {
 			parser: tsparser,
 			parserOptions: {
-				sourceType: "module",
 				project: "./tsconfig.json",
+				sourceType: "module",
+				ecmaVersion: 2022,
 			},
-			globals: globals.browser,
+			globals: {
+				...globals.browser,
+				...globals.node,
+			},
 		},
 		plugins: {
 			"@typescript-eslint": tseslint,
 			obsidianmd: obsidianmd,
 		},
 		rules: {
-			...tseslint.configs.recommended.rules,
-
-			// ==================== TypeScript Official Rules ====================
-			// 禁止未使用的变量，但允许未使用的参数
+			// TypeScript ESLint rules
 			"no-unused-vars": "off",
-			"@typescript-eslint/no-unused-vars": ["error", { args: "none" }],
-			// 允许使用 @ts-ignore 等注释
-			"@typescript-eslint/ban-ts-comment": "off",
-			// 允许直接使用原型方法
-			"no-prototype-builtins": "off",
-			// 允许空函数
-			"@typescript-eslint/no-empty-function": "off",
-			// 允许使用 any 类型
-			"@typescript-eslint/no-explicit-any": "off",
-
-			// ==================== Custom Rules ====================
-			// 允许显式声明可推断的类型
-			"@typescript-eslint/no-inferrable-types": "off",
-			// 允许混合使用空格和制表符
-			"no-mixed-spaces-and-tabs": "off",
-			"sort-imports": [
-				// 强制导入语句排序
+			"@typescript-eslint/no-unused-vars": [
 				"error",
 				{
-					ignoreCase: true, // 忽略大小写
-					ignoreDeclarationSort: true, // 忽略声明排序
-					ignoreMemberSort: false, // 不忽略成员排序
+					args: "none",
+					argsIgnorePattern: "^_",
+					varsIgnorePattern: "^_",
+				},
+			],
+			"@typescript-eslint/ban-ts-comment": "off",
+			"no-prototype-builtins": "off",
+			"@typescript-eslint/no-empty-function": "off",
+			"@typescript-eslint/no-explicit-any": "error",
+			"@typescript-eslint/require-await": "error",
+			"@typescript-eslint/no-unnecessary-type-assertion": "error",
+			"@typescript-eslint/no-floating-promises": "error",
+			"@typescript-eslint/no-misused-promises": "error",
+			"@typescript-eslint/await-thenable": "error",
+			"@typescript-eslint/no-base-to-string": "warn",
+			"@typescript-eslint/no-this-alias": "error",
+			"@typescript-eslint/no-deprecated": "warn",
+
+			// General ESLint rules
+			"no-console": ["error", { allow: ["warn", "error", "debug"] }],
+			"no-case-declarations": "error",
+			"no-constant-condition": "error",
+			"prefer-const": "error",
+			"no-var": "error",
+			"sort-imports": [
+				"error",
+				{
+					ignoreCase: true,
+					ignoreDeclarationSort: true,
+					ignoreMemberSort: false,
 					memberSyntaxSortOrder: [
 						"none",
 						"all",
 						"multiple",
 						"single",
-					], // 成员语法排序顺序
+					],
 				},
 			],
 
-			// ==================== Obsidianmd Rules ====================
-			// ====== 命令相关规则 ======
-			// 禁止在命令 ID 中使用 'command' 单词
-			"obsidianmd/commands/no-command-in-command-id": "error",
-			// 禁止在命令名称中使用 'command' 单词
-			"obsidianmd/commands/no-command-in-command-name": "error",
-			// 不建议为命令提供默认热键
-			"obsidianmd/commands/no-default-hotkeys": "warn",
-			// 禁止在命令 ID 中包含插件 ID
-			"obsidianmd/commands/no-plugin-id-in-command-id": "error",
-			// 禁止在命令名称中包含插件名称
-			"obsidianmd/commands/no-plugin-name-in-command-name": "error",
-
-			// ====== 内存泄漏防护规则 ======
-			// 在 onunload 中不要分离叶子节点
-			"obsidianmd/detach-leaves": "error",
-			// 禁止将插件作为组件传递给 MarkdownRenderer.render
-			"obsidianmd/no-plugin-as-component": "error",
-			// 禁止在插件中直接存储自定义视图的引用
-			"obsidianmd/no-view-references-in-plugin": "error",
-
-			// ====== 代码质量规则 ======
-			// 禁止使用模板中的示例代码
-			"obsidianmd/no-sample-code": "error",
-			// 禁止直接在 DOM 元素上设置样式，建议使用 CSS 类
-			"obsidianmd/no-static-styles-assignment": "error",
-			// 禁止类型转换为 TFile 或 TFolder，建议使用 instanceof 检查
-			"obsidianmd/no-tfile-tfolder-cast": "error",
-			// 禁止在 Obsidian 插件中向 DOM 附加禁止的元素
+			// Obsidian-specific rules
 			"obsidianmd/no-forbidden-elements": "error",
-
-			// ====== API 使用最佳实践 ======
-			// 优先使用 FileManager.trashFile() 而不是 Vault.trash() 或 Vault.delete()
-			"obsidianmd/prefer-file-manager-trash-file": "error",
-			// 建议使用内置的 AbstractInputSuggest 而不是常见的 TextInputSuggest 实现
-			"obsidianmd/prefer-abstract-input-suggest": "warn",
-			// 避免遍历所有文件来按路径查找文件
-			"obsidianmd/vault/iterate": "warn",
-
-			// ====== 平台兼容性规则 ======
-			// 禁止使用 navigator API 进行操作系统检测
+			"obsidianmd/no-static-styles-assignment": "error",
+			"obsidianmd/vault/iterate": "error",
+			"obsidianmd/detach-leaves": "error",
+			"obsidianmd/hardcoded-config-path": "error",
+			"obsidianmd/no-plugin-as-component": "error",
+			"obsidianmd/no-sample-code": "error",
+			"obsidianmd/no-tfile-tfolder-cast": "error",
+			"obsidianmd/no-view-references-in-plugin": "error",
 			"obsidianmd/platform": "error",
-			// 禁止在正则表达式中使用后行断言（某些 iOS 版本不支持）
+			"obsidianmd/prefer-file-manager-trash-file": "warn",
 			"obsidianmd/regex-lookbehind": "error",
-
-			// ====== 其他规则 ======
-			// 不建议使用带有两个参数的 Object.assign
-			"obsidianmd/object-assign": "warn",
-			// 重命名示例插件类名
 			"obsidianmd/sample-names": "error",
-			// 验证 LICENSE 文件中版权声明的结构
-			"obsidianmd/validate-license": "error",
-			// 验证 manifest.json 的结构
-			"obsidianmd/validate-manifest": "error",
-
-			// ====== 设置页面规则 ======
-			// 禁止在设置页面中使用手动创建的 HTML 标题元素
-			"obsidianmd/settings-tab/no-manual-html-headings": "error",
-			// 避免设置标题中的反模式
-			"obsidianmd/settings-tab/no-problematic-settings-headings": "error",
-
-			// ====== UI 文本规范 ======
 			"obsidianmd/ui/sentence-case": [
-				"warn",
+				"error",
 				{
-					// 强制 UI 字符串使用句子大小写
-					brands: [], // 品牌名称例外列表
-					acronyms: ["API", "UI", "URL", "HTML", "CSS", "JS", "TS"], // 首字母缩写词例外列表
-					enforceCamelCaseLower: true, // 强制 CamelCase 转换为小写
+					enforceCamelCaseLower: true,
+					// Note: providing brands/acronyms REPLACES defaults, so we include needed defaults
+					brands: [
+						// From defaults (essential ones we use)
+						"iOS",
+						"iPadOS",
+						"macOS",
+						"Windows",
+						"Android",
+						"Linux",
+						"Obsidian",
+						"Obsidian Sync",
+						"Obsidian Publish",
+						"Google Drive",
+						"Dropbox",
+						"OneDrive",
+						"iCloud Drive",
+						"Excalidraw",
+						"Mermaid",
+						"Markdown",
+						"LaTeX",
+						"JavaScript",
+						"TypeScript",
+						"Node.js",
+						"npm",
+						"pnpm",
+						"Yarn",
+						"Git",
+						"GitHub",
+						"GitLab",
+						"VS Code",
+						"Visual Studio Code",
+						// Canvas Roots specific
+						"Canvas Roots",
+						"Calendarium",
+						"Templater",
+						"Dataview",
+						"Leaflet",
+						// Genealogy formats and software
+						"GEDCOM",
+						"GEDCOM X",
+						"GedcomX",
+						"Gramps",
+						"FamilySearch",
+						// Fictional universes and eras
+						"Middle-earth",
+						"Westeros",
+						"Star Wars",
+						"Shire",
+						"Third Age",
+						"Second Age",
+						"First Age",
+						"Fourth Age",
+						// Genealogical numbering systems
+						"Ahnentafel",
+						"d'Aboville",
+						"Henry",
+						// Font names
+						"Comic Shanns",
+						"Lilita One",
+						"Lexend Deca",
+						"Inter",
+						"Roboto",
+						"Open Sans",
+						"Fira Code",
+						"JetBrains Mono",
+						// Map providers
+						"OpenStreetMap",
+						"Mapbox",
+						"Stadia",
+						"Thunderforest",
+						"CartoDB",
+						"Esri",
+					],
+					acronyms: [
+						// From defaults (essential ones)
+						"API",
+						"HTTP",
+						"HTTPS",
+						"URL",
+						"DNS",
+						"TCP",
+						"IP",
+						"SSH",
+						"TLS",
+						"SSL",
+						"JSON",
+						"XML",
+						"HTML",
+						"CSS",
+						"PDF",
+						"CSV",
+						"YAML",
+						"SQL",
+						"PNG",
+						"JPG",
+						"JPEG",
+						"GIF",
+						"SVG",
+						"SDK",
+						"IDE",
+						"CLI",
+						"GUI",
+						"REST",
+						"UI",
+						"OK",
+						"ID",
+						"UUID",
+						"GUID",
+						"DOM",
+						"CDN",
+						"FAQ",
+						"AI",
+						"ML",
+						// Canvas Roots specific
+						"TA",
+						"SA",
+						"FA", // Middle-earth era abbreviations
+						"GEDCOM",
+						"PII", // Personally Identifiable Information
+						"AC",
+						"BC", // Time period abbreviations (Westeros, historical)
+					],
 				},
 			],
+			"obsidianmd/commands/no-command-in-command-id": "error",
+			"obsidianmd/commands/no-command-in-command-name": "error",
+			"obsidianmd/commands/no-default-hotkeys": "error",
+			"obsidianmd/commands/no-plugin-id-in-command-id": "error",
+			"obsidianmd/commands/no-plugin-name-in-command-name": "error",
+			"obsidianmd/settings-tab/no-manual-html-headings": "error",
+			"obsidianmd/settings-tab/no-problematic-settings-headings": "error",
 		},
-	},
-	{
-		ignores: [
-			"node_modules/**",
-			"main.js",
-			"scripts/**",
-			"*.js",
-			"test/**/*.ts",
-		],
 	},
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,6 @@
 				"react-dom": "^19.2.3"
 			},
 			"devDependencies": {
-				"@codemirror/state": "^6.5.2",
-				"@codemirror/view": "^6.39.4",
 				"@types/jest": "^30.0.0",
 				"@types/node": "^25.0.2",
 				"@types/react": "^19.2.7",
@@ -570,21 +568,23 @@
 			"license": "MIT"
 		},
 		"node_modules/@codemirror/state": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmmirror.com/@codemirror/state/-/state-6.5.2.tgz",
-			"integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmmirror.com/@codemirror/state/-/state-6.5.0.tgz",
+			"integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@marijn/find-cluster-break": "^1.0.0"
 			}
 		},
 		"node_modules/@codemirror/view": {
-			"version": "6.39.4",
-			"resolved": "https://registry.npmmirror.com/@codemirror/view/-/view-6.39.4.tgz",
-			"integrity": "sha512-xMF6OfEAUVY5Waega4juo1QGACfNkNF+aJLqpd8oUJz96ms2zbfQ9Gh35/tI3y8akEV31FruKfj7hBnIU/nkqA==",
+			"version": "6.38.6",
+			"resolved": "https://registry.npmmirror.com/@codemirror/view/-/view-6.38.6.tgz",
+			"integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@codemirror/state": "^6.5.0",
 				"crelt": "^1.0.6",
@@ -1305,6 +1305,23 @@
 				"url": "https://eslint.org/donate"
 			}
 		},
+		"node_modules/@eslint/json": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmmirror.com/@eslint/json/-/json-0.14.0.tgz",
+			"integrity": "sha512-rvR/EZtvUG3p9uqrSmcDJPYSH7atmWr0RnFWN6m917MAPx82+zQgPUmDu0whPFG6XTyM0vB/hR6c1Q63OaYtCQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@eslint/core": "^0.17.0",
+				"@eslint/plugin-kit": "^0.4.1",
+				"@humanwhocodes/momoa": "^3.3.10",
+				"natural-compare": "^1.4.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
 		"node_modules/@eslint/object-schema": {
 			"version": "2.1.7",
 			"resolved": "https://registry.npmmirror.com/@eslint/object-schema/-/object-schema-2.1.7.tgz",
@@ -1403,6 +1420,17 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
+		"node_modules/@humanwhocodes/momoa": {
+			"version": "3.3.10",
+			"resolved": "https://registry.npmmirror.com/@humanwhocodes/momoa/-/momoa-3.3.10.tgz",
+			"integrity": "sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@humanwhocodes/retry": {
@@ -1961,7 +1989,8 @@
 			"resolved": "https://registry.npmmirror.com/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
 			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@microsoft/eslint-plugin-sdl": {
 			"version": "1.1.0",
@@ -3707,9 +3736,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.0.2",
-			"resolved": "https://registry.npmmirror.com/@types/node/-/node-25.0.2.tgz",
-			"integrity": "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==",
+			"version": "25.0.3",
+			"resolved": "https://registry.npmmirror.com/@types/node/-/node-25.0.3.tgz",
+			"integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3727,7 +3756,7 @@
 			"version": "19.2.7",
 			"resolved": "https://registry.npmmirror.com/@types/react/-/react-19.2.7.tgz",
 			"integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"csstype": "^3.2.2"
@@ -3737,7 +3766,7 @@
 			"version": "19.2.3",
 			"resolved": "https://registry.npmmirror.com/@types/react-dom/-/react-dom-19.2.3.tgz",
 			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
@@ -3814,16 +3843,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.49.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/parser/-/parser-8.49.0.tgz",
-			"integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
+			"version": "8.50.1",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/parser/-/parser-8.50.1.tgz",
+			"integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.49.0",
-				"@typescript-eslint/types": "8.49.0",
-				"@typescript-eslint/typescript-estree": "8.49.0",
-				"@typescript-eslint/visitor-keys": "8.49.0",
+				"@typescript-eslint/scope-manager": "8.50.1",
+				"@typescript-eslint/types": "8.50.1",
+				"@typescript-eslint/typescript-estree": "8.50.1",
+				"@typescript-eslint/visitor-keys": "8.50.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -3838,15 +3867,64 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.49.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/project-service/-/project-service-8.49.0.tgz",
-			"integrity": "sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==",
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.50.1",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/scope-manager/-/scope-manager-8.50.1.tgz",
+			"integrity": "sha512-mfRx06Myt3T4vuoHaKi8ZWNTPdzKPNBhiblze5N50//TSHOAQQevl/aolqA/BcqqbJ88GUnLqjjcBc8EWdBcVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.49.0",
-				"@typescript-eslint/types": "^8.49.0",
+				"@typescript-eslint/types": "8.50.1",
+				"@typescript-eslint/visitor-keys": "8.50.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.50.1",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.1.tgz",
+			"integrity": "sha512-IrDKrw7pCRUR94zeuCSUWQ+w8JEf5ZX5jl/e6AHGSLi1/zIr0lgutfn/7JpfCey+urpgQEdrZVYzCaVVKiTwhQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.50.1",
+				"eslint-visitor-keys": "^4.2.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/project-service": {
+			"version": "8.50.1",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/project-service/-/project-service-8.50.1.tgz",
+			"integrity": "sha512-E1ur1MCVf+YiP89+o4Les/oBAVzmSbeRB0MQLfSlYtbWU17HPxZ6Bhs5iYmKZRALvEuBoXIZMOIRRc/P++Ortg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/tsconfig-utils": "^8.50.1",
+				"@typescript-eslint/types": "^8.50.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -3878,10 +3956,24 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/tsconfig-utils": {
+		"node_modules/@typescript-eslint/scope-manager/node_modules/@typescript-eslint/types": {
 			"version": "8.49.0",
-			"resolved": "https://registry.npmmirror.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.49.0.tgz",
-			"integrity": "sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA==",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/types/-/types-8.49.0.tgz",
+			"integrity": "sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.50.1",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.1.tgz",
+			"integrity": "sha512-ooHmotT/lCWLXi55G4mvaUF60aJa012QzvLK0Y+Mp4WdSt17QhMhWOaBWeGTFVkb2gDgBe19Cxy1elPXylslDw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3920,7 +4012,46 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/@typescript-eslint/types": {
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/project-service": {
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/project-service/-/project-service-8.49.0.tgz",
+			"integrity": "sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/tsconfig-utils": "^8.49.0",
+				"@typescript-eslint/types": "^8.49.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.49.0.tgz",
+			"integrity": "sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
 			"version": "8.49.0",
 			"resolved": "https://registry.npmmirror.com/@typescript-eslint/types/-/types-8.49.0.tgz",
 			"integrity": "sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==",
@@ -3934,7 +4065,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@typescript-eslint/typescript-estree": {
+		"node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
 			"version": "8.49.0",
 			"resolved": "https://registry.npmmirror.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.49.0.tgz",
 			"integrity": "sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA==",
@@ -3962,6 +4093,79 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
+		"node_modules/@typescript-eslint/types": {
+			"version": "8.50.1",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/types/-/types-8.50.1.tgz",
+			"integrity": "sha512-v5lFIS2feTkNyMhd7AucE/9j/4V9v5iIbpVRncjk/K0sQ6Sb+Np9fgYS/63n6nwqahHQvbmujeBL7mp07Q9mlA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.50.1",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.50.1.tgz",
+			"integrity": "sha512-woHPdW+0gj53aM+cxchymJCrh0cyS7BTIdcDxWUNsclr9VDkOSbqC13juHzxOmQ22dDkMZEpZB+3X1WpUvzgVQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/project-service": "8.50.1",
+				"@typescript-eslint/tsconfig-utils": "8.50.1",
+				"@typescript-eslint/types": "8.50.1",
+				"@typescript-eslint/visitor-keys": "8.50.1",
+				"debug": "^4.3.4",
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"tinyglobby": "^0.2.15",
+				"ts-api-utils": "^2.1.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.50.1",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.1.tgz",
+			"integrity": "sha512-IrDKrw7pCRUR94zeuCSUWQ+w8JEf5ZX5jl/e6AHGSLi1/zIr0lgutfn/7JpfCey+urpgQEdrZVYzCaVVKiTwhQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.50.1",
+				"eslint-visitor-keys": "^4.2.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
 		"node_modules/@typescript-eslint/utils": {
 			"version": "8.49.0",
 			"resolved": "https://registry.npmmirror.com/@typescript-eslint/utils/-/utils-8.49.0.tgz",
@@ -3986,6 +4190,87 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
+		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/project-service": {
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/project-service/-/project-service-8.49.0.tgz",
+			"integrity": "sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/tsconfig-utils": "^8.49.0",
+				"@typescript-eslint/types": "^8.49.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.49.0.tgz",
+			"integrity": "sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/types/-/types-8.49.0.tgz",
+			"integrity": "sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.49.0.tgz",
+			"integrity": "sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/project-service": "8.49.0",
+				"@typescript-eslint/tsconfig-utils": "8.49.0",
+				"@typescript-eslint/types": "8.49.0",
+				"@typescript-eslint/visitor-keys": "8.49.0",
+				"debug": "^4.3.4",
+				"minimatch": "^9.0.4",
+				"semver": "^7.6.0",
+				"tinyglobby": "^0.2.15",
+				"ts-api-utils": "^2.1.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
 		"node_modules/@typescript-eslint/visitor-keys": {
 			"version": "8.49.0",
 			"resolved": "https://registry.npmmirror.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.49.0.tgz",
@@ -3996,6 +4281,20 @@
 				"@typescript-eslint/types": "8.49.0",
 				"eslint-visitor-keys": "^4.2.1"
 			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys/node_modules/@typescript-eslint/types": {
+			"version": "8.49.0",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/types/-/types-8.49.0.tgz",
+			"integrity": "sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==",
+			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -4718,9 +5017,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.9.7",
-			"resolved": "https://registry.npmmirror.com/baseline-browser-mapping/-/baseline-browser-mapping-2.9.7.tgz",
-			"integrity": "sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg==",
+			"version": "2.9.11",
+			"resolved": "https://registry.npmmirror.com/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
+			"integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -4898,9 +5197,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001760",
-			"resolved": "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001760.tgz",
-			"integrity": "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==",
+			"version": "1.0.30001761",
+			"resolved": "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001761.tgz",
+			"integrity": "sha512-JF9ptu1vP2coz98+5051jZ4PwQgd2ni8A+gYSN7EA7dPKIMf0pDlSUxhdmVOaV3/fYK5uWBkgSXJaRLr4+3A6g==",
 			"dev": true,
 			"funding": [
 				{
@@ -5332,7 +5631,8 @@
 			"resolved": "https://registry.npmmirror.com/crelt/-/crelt-1.0.6.tgz",
 			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -5366,7 +5666,7 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz",
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/data-view-buffer": {
@@ -5442,9 +5742,9 @@
 			}
 		},
 		"node_modules/dedent": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmmirror.com/dedent/-/dedent-1.7.0.tgz",
-			"integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
+			"version": "1.7.1",
+			"resolved": "https://registry.npmmirror.com/dedent/-/dedent-1.7.1.tgz",
+			"integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -6693,24 +6993,6 @@
 				"bser": "2.1.1"
 			}
 		},
-		"node_modules/fdir": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.5.0.tgz",
-			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.0.0"
-			},
-			"peerDependencies": {
-				"picomatch": "^3 || ^4"
-			},
-			"peerDependenciesMeta": {
-				"picomatch": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmmirror.com/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6822,9 +7104,9 @@
 			}
 		},
 		"node_modules/fs-extra": {
-			"version": "11.3.2",
-			"resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-11.3.2.tgz",
-			"integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+			"version": "11.3.3",
+			"resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-11.3.3.tgz",
+			"integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10780,7 +11062,8 @@
 			"resolved": "https://registry.npmmirror.com/style-mod/-/style-mod-4.1.3.tgz",
 			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -10941,6 +11224,24 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/tinyglobby/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/tinyglobby/node_modules/picomatch": {
@@ -11254,6 +11555,164 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/typescript-eslint": {
+			"version": "8.50.1",
+			"resolved": "https://registry.npmmirror.com/typescript-eslint/-/typescript-eslint-8.50.1.tgz",
+			"integrity": "sha512-ytTHO+SoYSbhAH9CrYnMhiLx8To6PSSvqnvXyPUgPETCvB6eBKmTI9w6XMPS3HsBRGkwTVBX+urA8dYQx6bHfQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@typescript-eslint/eslint-plugin": "8.50.1",
+				"@typescript-eslint/parser": "8.50.1",
+				"@typescript-eslint/typescript-estree": "8.50.1",
+				"@typescript-eslint/utils": "8.50.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "8.50.1",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.1.tgz",
+			"integrity": "sha512-PKhLGDq3JAg0Jk/aK890knnqduuI/Qj+udH7wCf0217IGi4gt+acgCyPVe79qoT+qKUvHMDQkwJeKW9fwl8Cyw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@eslint-community/regexpp": "^4.10.0",
+				"@typescript-eslint/scope-manager": "8.50.1",
+				"@typescript-eslint/type-utils": "8.50.1",
+				"@typescript-eslint/utils": "8.50.1",
+				"@typescript-eslint/visitor-keys": "8.50.1",
+				"ignore": "^7.0.0",
+				"natural-compare": "^1.4.0",
+				"ts-api-utils": "^2.1.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^8.50.1",
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.50.1",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/scope-manager/-/scope-manager-8.50.1.tgz",
+			"integrity": "sha512-mfRx06Myt3T4vuoHaKi8ZWNTPdzKPNBhiblze5N50//TSHOAQQevl/aolqA/BcqqbJ88GUnLqjjcBc8EWdBcVw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@typescript-eslint/types": "8.50.1",
+				"@typescript-eslint/visitor-keys": "8.50.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/type-utils": {
+			"version": "8.50.1",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/type-utils/-/type-utils-8.50.1.tgz",
+			"integrity": "sha512-7J3bf022QZE42tYMO6SL+6lTPKFk/WphhRPe9Tw/el+cEwzLz1Jjz2PX3GtGQVxooLDKeMVmMt7fWpYRdG5Etg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@typescript-eslint/types": "8.50.1",
+				"@typescript-eslint/typescript-estree": "8.50.1",
+				"@typescript-eslint/utils": "8.50.1",
+				"debug": "^4.3.4",
+				"ts-api-utils": "^2.1.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+			"version": "8.50.1",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/utils/-/utils-8.50.1.tgz",
+			"integrity": "sha512-lCLp8H1T9T7gPbEuJSnHwnSuO9mDf8mfK/Nion5mZmiEaQD9sWf9W4dfeFqRyqRjF06/kBuTmAqcs9sewM2NbQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.7.0",
+				"@typescript-eslint/scope-manager": "8.50.1",
+				"@typescript-eslint/types": "8.50.1",
+				"@typescript-eslint/typescript-estree": "8.50.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.50.1",
+			"resolved": "https://registry.npmmirror.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.1.tgz",
+			"integrity": "sha512-IrDKrw7pCRUR94zeuCSUWQ+w8JEf5ZX5jl/e6AHGSLi1/zIr0lgutfn/7JpfCey+urpgQEdrZVYzCaVVKiTwhQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@typescript-eslint/types": "8.50.1",
+				"eslint-visitor-keys": "^4.2.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/typescript-eslint/node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmmirror.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
 		"node_modules/uglify-js": {
 			"version": "3.19.3",
 			"resolved": "https://registry.npmmirror.com/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -11353,9 +11812,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmmirror.com/update-browserslist-db/-/update-browserslist-db-1.2.2.tgz",
-			"integrity": "sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmmirror.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"dev": true,
 			"funding": [
 				{
@@ -11483,7 +11942,8 @@
 			"resolved": "https://registry.npmmirror.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/walker": {
 			"version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
 		"changelog:all": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0 -n ./scripts/changelog-option.js",
 		"release:pre": "npm run build && npm run version && npm run changelog:u && npm i",
 		"release:tag": "node scripts/release-tag.mjs",
-		"lint": "eslint . --ext .ts,.tsx",
-		"lint:fix": "eslint . --ext .ts,.tsx --fix",
+		"lint": "eslint .",
+		"lint:fix": "eslint . --fix",
 		"test": "jest",
 		"test:watch": "jest --watch",
 		"link:data": "node scripts/link-data.mjs"
@@ -29,8 +29,6 @@
 		"node": ">=18.x"
 	},
 	"devDependencies": {
-		"@codemirror/state": "^6.5.2",
-		"@codemirror/view": "^6.39.4",
 		"@types/jest": "^30.0.0",
 		"@types/node": "^25.0.2",
 		"@types/react": "^19.2.7",


### PR DESCRIPTION
更新并修正 package-lock.json 中若干依赖的版本和元数据信息。
主要改动包括将 @codemirror/state 从 6.5.2 回退到 6.5.0，
将 @codemirror/view 从 6.39.4 回退到 6.38.6，修正对应的 resolved
和 integrity 字段，同时标记若干包为 peer 依赖（peer: true）。
新增或更新了多个包的锁定信息（例如 @eslint/json、@humanwhocodes/momoa），
并将 @types/node 升级到 25.0.3 以及将 @types/react 和
@types/react-dom 的 dev 字段调整为 devOptional。
此外，更新 @typescript-eslint/parser 到 8.50.1。

这些更改用于恢复或统一依赖版本、修正一致性問題，確保鎖檔與實際
安裝來源一致，減少不同环境下的安装差异并提升构建稳定性。