### PR TITLE
fix: 用 CSS 分离样式并简组件逻辑

### DIFF
--- a/src/components/progress-circle/ProgressCircle.css
+++ b/src/components/progress-circle/ProgressCircle.css
@@ -9,10 +9,47 @@
 	height: 2.5rem;
 }
 
+/* SVG 根元素 */
+.NToc__progress-circle-wrapper .CircularProgressbar {
+	width: 100%;
+	height: 100%;
+	vertical-align: middle;
+}
+
+/* 进度条路径 (已完成的进度) */
+.NToc__progress-circle-wrapper .CircularProgressbar-path {
+	stroke: var(--interactive-accent);
+	stroke-linecap: round;
+	transition: stroke-dashoffset 0.5s ease 0s;
+}
+
+/* 轨道 (背景圆环) */
+.NToc__progress-circle-wrapper .CircularProgressbar-trail {
+	stroke: var(--background-modifier-border);
+	stroke-linecap: round;
+}
+
+/* 文本 */
+.NToc__progress-circle-wrapper .CircularProgressbar-text {
+	fill: var(--text-normal);
+	font-size: 1.5rem;
+	dominant-baseline: middle;
+	text-anchor: middle;
+}
+
+/* 背景 (仅在 background prop 为 true 时生效) */
+.NToc__progress-circle-wrapper .CircularProgressbar-background {
+	fill: transparent;
+}
+
 /* 响应式调整 */
 @media (max-width: 768px) {
 	.NToc__progress-circle-wrapper {
 		width: 2rem;
 		height: 2rem;
+	}
+
+	.NToc__progress-circle-wrapper .CircularProgressbar-text {
+		font-size: 1.25rem;
 	}
 }

--- a/src/components/progress-circle/ProgressCircle.tsx
+++ b/src/components/progress-circle/ProgressCircle.tsx
@@ -1,6 +1,5 @@
 import { FC } from "react";
-import { buildStyles, CircularProgressbar } from "react-circular-progressbar";
-import "react-circular-progressbar/dist/styles.css";
+import { CircularProgressbar } from "react-circular-progressbar";
 import "./ProgressCircle.css";
 
 interface ProgressCircleProps {
@@ -30,24 +29,7 @@ export const ProgressCircle: FC<ProgressCircleProps> = ({
 
 	return (
 		<div className="NToc__progress-circle-wrapper">
-			<CircularProgressbar
-				value={percentage}
-				text={displayText}
-				styles={buildStyles({
-					// 路径颜色 (进度条)
-					pathColor: "var(--interactive-accent)",
-					// 文本颜色
-					textColor: "var(--text-normal)",
-					// 轨道颜色 (背景圆环)
-					trailColor: "var(--background-modifier-border)",
-					// 背景色
-					backgroundColor: "transparent",
-					// 文本大小 - 根据圆环大小动态调整
-					textSize: `1.5rem`,
-					// 路径线帽样式
-					strokeLinecap: "round",
-				})}
-			/>
+			<CircularProgressbar value={percentage} text={displayText} />
 		</div>
 	);
 };


### PR DESCRIPTION
将 ProgressCircle 的样式从内联样式和 buildStyles 提取到
独立的 CSS 文件，新增针对 SVG 元素、路径、轨道、文本和背景的
具体样式规则，包含响应式字体和尺寸调整。删除对
react-circular-progressbar 的 buildStyles 和默认样式导入，
组件中直接使用 CircularProgressbar 并依赖外部 CSS 控制外观。

这样做的原因是将样式与逻辑分离，减小组件实现的复杂度，
便于主题变量（CSS 变量）和响应式调整的集中管理，同时减少
运行时的样式构建开销，提升可维护性和一致性。