### PR TITLE
chore(deps): 更新 package-lock 元数据并调整依赖位置

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
 			"version": "1.2.6",
 			"license": "GPL-3.0-only",
 			"dependencies": {
-				"conventional-changelog-cli": "^5.0.0",
-				"dotenv": "^17.2.3",
 				"lucide-react": "^0.561.0",
 				"radix-ui": "^1.4.3",
 				"react": "^19.2.3",
@@ -25,6 +23,8 @@
 				"@typescript-eslint/eslint-plugin": "8.49.0",
 				"@typescript-eslint/parser": "^8.49.0",
 				"builtin-modules": "5.0.0",
+				"conventional-changelog-cli": "^5.0.0",
+				"dotenv": "^17.2.3",
 				"esbuild": "0.27.1",
 				"eslint": "^9.39.2",
 				"eslint-plugin-obsidianmd": "^0.1.9",
@@ -45,6 +45,7 @@
 			"version": "7.27.1",
 			"resolved": "https://registry.npmmirror.com/@babel/code-frame/-/code-frame-7.27.1.tgz",
 			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.27.1",
@@ -226,6 +227,7 @@
 			"version": "7.28.5",
 			"resolved": "https://registry.npmmirror.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
 			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -594,6 +596,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmmirror.com/@conventional-changelog/git-client/-/git-client-1.0.1.tgz",
 			"integrity": "sha512-PJEqBwAleffCMETaVm/fUgHldzBE35JFk3/9LL6NUA5EXa3qednu+UT6M7E5iBu3zIQZCULYIiZ90fBYHt6xUw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/semver": "^7.5.5",
@@ -1448,6 +1451,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmmirror.com/@hutson/parse-repository-url/-/parse-repository-url-5.0.0.tgz",
 			"integrity": "sha512-e5+YUKENATs1JgYHMzTr2MW/NDcXGfYFAuOQU8gJgF/kEh4EqKgfGrfLI67bMD4tbhZVlkigz/9YYwWcbOFthg==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=10.13.0"
@@ -3745,6 +3749,7 @@
 			"version": "2.4.4",
 			"resolved": "https://registry.npmmirror.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
 			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
@@ -3771,6 +3776,7 @@
 			"version": "7.7.1",
 			"resolved": "https://registry.npmmirror.com/@types/semver/-/semver-7.7.1.tgz",
 			"integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/stack-utils": {
@@ -4613,6 +4619,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmmirror.com/add-stream/-/add-stream-1.0.0.tgz",
 			"integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/ajv": {
@@ -4731,6 +4738,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmmirror.com/array-ify/-/array-ify-1.0.0.tgz",
 			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/array-includes": {
@@ -5379,6 +5387,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmmirror.com/compare-func/-/compare-func-2.0.0.tgz",
 			"integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"array-ify": "^1.0.0",
@@ -5396,6 +5405,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmmirror.com/conventional-changelog/-/conventional-changelog-6.0.0.tgz",
 			"integrity": "sha512-tuUH8H/19VjtD9Ig7l6TQRh+Z0Yt0NZ6w/cCkkyzUbGQTnUEmKfGtkC9gGfVgCfOL1Rzno5NgNF4KY8vR+Jo3w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"conventional-changelog-angular": "^8.0.0",
@@ -5418,6 +5428,7 @@
 			"version": "8.1.0",
 			"resolved": "https://registry.npmmirror.com/conventional-changelog-angular/-/conventional-changelog-angular-8.1.0.tgz",
 			"integrity": "sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"compare-func": "^2.0.0"
@@ -5430,6 +5441,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmmirror.com/conventional-changelog-atom/-/conventional-changelog-atom-5.0.0.tgz",
 			"integrity": "sha512-WfzCaAvSCFPkznnLgLnfacRAzjgqjLUjvf3MftfsJzQdDICqkOOpcMtdJF3wTerxSpv2IAAjX8doM3Vozqle3g==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=18"
@@ -5439,6 +5451,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmmirror.com/conventional-changelog-cli/-/conventional-changelog-cli-5.0.0.tgz",
 			"integrity": "sha512-9Y8fucJe18/6ef6ZlyIlT2YQUbczvoQZZuYmDLaGvcSBP+M6h+LAvf7ON7waRxKJemcCII8Yqu5/8HEfskTxJQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"add-stream": "^1.0.0",
@@ -5457,6 +5470,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmmirror.com/conventional-changelog-codemirror/-/conventional-changelog-codemirror-5.0.0.tgz",
 			"integrity": "sha512-8gsBDI5Y3vrKUCxN6Ue8xr6occZ5nsDEc4C7jO/EovFGozx8uttCAyfhRrvoUAWi2WMm3OmYs+0mPJU7kQdYWQ==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=18"
@@ -5466,6 +5480,7 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmmirror.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
 			"integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"compare-func": "^2.0.0"
@@ -5478,6 +5493,7 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmmirror.com/conventional-changelog-core/-/conventional-changelog-core-8.0.0.tgz",
 			"integrity": "sha512-EATUx5y9xewpEe10UEGNpbSHRC6cVZgO+hXQjofMqpy+gFIrcGvH3Fl6yk2VFKh7m+ffenup2N7SZJYpyD9evw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@hutson/parse-repository-url": "^5.0.0",
@@ -5499,6 +5515,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmmirror.com/conventional-changelog-ember/-/conventional-changelog-ember-5.0.0.tgz",
 			"integrity": "sha512-RPflVfm5s4cSO33GH/Ey26oxhiC67akcxSKL8CLRT3kQX2W3dbE19sSOM56iFqUJYEwv9mD9r6k79weWe1urfg==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=18"
@@ -5508,6 +5525,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmmirror.com/conventional-changelog-eslint/-/conventional-changelog-eslint-6.0.0.tgz",
 			"integrity": "sha512-eiUyULWjzq+ybPjXwU6NNRflApDWlPEQEHvI8UAItYW/h22RKkMnOAtfCZxMmrcMO1OKUWtcf2MxKYMWe9zJuw==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=18"
@@ -5517,6 +5535,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmmirror.com/conventional-changelog-express/-/conventional-changelog-express-5.0.0.tgz",
 			"integrity": "sha512-D8Q6WctPkQpvr2HNCCmwU5GkX22BVHM0r4EW8vN0230TSyS/d6VQJDAxGb84lbg0dFjpO22MwmsikKL++Oo/oQ==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=18"
@@ -5526,6 +5545,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmmirror.com/conventional-changelog-jquery/-/conventional-changelog-jquery-6.0.0.tgz",
 			"integrity": "sha512-2kxmVakyehgyrho2ZHBi90v4AHswkGzHuTaoH40bmeNqUt20yEkDOSpw8HlPBfvEQBwGtbE+5HpRwzj6ac2UfA==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=18"
@@ -5535,6 +5555,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmmirror.com/conventional-changelog-jshint/-/conventional-changelog-jshint-5.0.0.tgz",
 			"integrity": "sha512-gGNphSb/opc76n2eWaO6ma4/Wqu3tpa2w7i9WYqI6Cs2fncDSI2/ihOfMvXveeTTeld0oFvwMVNV+IYQIk3F3g==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"compare-func": "^2.0.0"
@@ -5547,6 +5568,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmmirror.com/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-5.0.0.tgz",
 			"integrity": "sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -5556,6 +5578,7 @@
 			"version": "8.2.0",
 			"resolved": "https://registry.npmmirror.com/conventional-changelog-writer/-/conventional-changelog-writer-8.2.0.tgz",
 			"integrity": "sha512-Y2aW4596l9AEvFJRwFGJGiQjt2sBYTjPD18DdvxX9Vpz0Z7HQ+g1Z+6iYDAm1vR3QOJrDBkRHixHK/+FhkR6Pw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"conventional-commits-filter": "^5.0.0",
@@ -5574,6 +5597,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmmirror.com/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
 			"integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -5583,6 +5607,7 @@
 			"version": "6.2.1",
 			"resolved": "https://registry.npmmirror.com/conventional-commits-parser/-/conventional-commits-parser-6.2.1.tgz",
 			"integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"meow": "^13.0.0"
@@ -5817,6 +5842,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmmirror.com/dot-prop/-/dot-prop-5.3.0.tgz",
 			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-obj": "^2.0.0"
@@ -5829,6 +5855,7 @@
 			"version": "17.2.3",
 			"resolved": "https://registry.npmmirror.com/dotenv/-/dotenv-17.2.3.tgz",
 			"integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=12"
@@ -7014,6 +7041,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmmirror.com/find-up-simple/-/find-up-simple-1.0.1.tgz",
 			"integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -7290,6 +7318,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmmirror.com/git-raw-commits/-/git-raw-commits-5.0.0.tgz",
 			"integrity": "sha512-I2ZXrXeOc0KrCvC7swqtIFXFN+rbjnC7b2T943tvemIOVNl+XP8YnA9UVwqFhzzLClnSA60KR/qEjLpXzs73Qg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@conventional-changelog/git-client": "^1.0.0",
@@ -7306,6 +7335,7 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmmirror.com/git-semver-tags/-/git-semver-tags-8.0.0.tgz",
 			"integrity": "sha512-N7YRIklvPH3wYWAR2vysaqGLPRcpwQ0GKdlqTiVN5w1UmCdaeY3K8s6DMKRCh54DDdzyt/OAB6C8jgVtb7Y2Fg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@conventional-changelog/git-client": "^1.0.0",
@@ -7406,6 +7436,7 @@
 			"version": "4.7.8",
 			"resolved": "https://registry.npmmirror.com/handlebars/-/handlebars-4.7.8.tgz",
 			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"minimist": "^1.2.5",
@@ -7521,6 +7552,7 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmmirror.com/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
 			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"lru-cache": "^10.0.1"
@@ -7607,6 +7639,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmmirror.com/index-to-position/-/index-to-position-1.2.0.tgz",
 			"integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -7927,6 +7960,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmmirror.com/is-obj/-/is-obj-2.0.0.tgz",
 			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -8835,6 +8869,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
@@ -9092,6 +9127,7 @@
 			"version": "10.4.3",
 			"resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-10.4.3.tgz",
 			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/lucide-react": {
@@ -9150,6 +9186,7 @@
 			"version": "13.2.0",
 			"resolved": "https://registry.npmmirror.com/meow/-/meow-13.2.0.tgz",
 			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -9209,6 +9246,7 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmmirror.com/minimist/-/minimist-1.2.8.tgz",
 			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -9294,6 +9332,7 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmmirror.com/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/node-int64": {
@@ -9314,6 +9353,7 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmmirror.com/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
 			"integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"hosted-git-info": "^7.0.0",
@@ -9686,6 +9726,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
@@ -10132,6 +10173,7 @@
 			"version": "11.0.0",
 			"resolved": "https://registry.npmmirror.com/read-package-up/-/read-package-up-11.0.0.tgz",
 			"integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"find-up-simple": "^1.0.0",
@@ -10149,6 +10191,7 @@
 			"version": "4.41.0",
 			"resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-4.41.0.tgz",
 			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
 			"engines": {
 				"node": ">=16"
@@ -10161,6 +10204,7 @@
 			"version": "9.0.1",
 			"resolved": "https://registry.npmmirror.com/read-pkg/-/read-pkg-9.0.1.tgz",
 			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/normalize-package-data": "^2.4.3",
@@ -10180,6 +10224,7 @@
 			"version": "8.3.0",
 			"resolved": "https://registry.npmmirror.com/parse-json/-/parse-json-8.3.0.tgz",
 			"integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.26.2",
@@ -10197,6 +10242,7 @@
 			"version": "4.41.0",
 			"resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-4.41.0.tgz",
 			"integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+			"dev": true,
 			"license": "(MIT OR CC0-1.0)",
 			"engines": {
 				"node": ">=16"
@@ -10449,6 +10495,7 @@
 			"version": "7.7.3",
 			"resolved": "https://registry.npmmirror.com/semver/-/semver-7.7.3.tgz",
 			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -10632,6 +10679,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmmirror.com/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -10662,6 +10710,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmmirror.com/spdx-correct/-/spdx-correct-3.2.0.tgz",
 			"integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"spdx-expression-parse": "^3.0.0",
@@ -10672,12 +10721,14 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmmirror.com/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
 			"integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+			"dev": true,
 			"license": "CC-BY-3.0"
 		},
 		"node_modules/spdx-expression-parse": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmmirror.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
 			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"spdx-exceptions": "^2.1.0",
@@ -10688,6 +10739,7 @@
 			"version": "3.0.22",
 			"resolved": "https://registry.npmmirror.com/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
 			"integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+			"dev": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/sprintf-js": {
@@ -11075,6 +11127,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmmirror.com/temp-dir/-/temp-dir-3.0.0.tgz",
 			"integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.16"
@@ -11084,6 +11137,7 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmmirror.com/tempfile/-/tempfile-5.0.0.tgz",
 			"integrity": "sha512-bX655WZI/F7EoTDw9JvQURqAXiPHi8o8+yFxPF2lWYyz1aHnmMRuXWqL6YB6GmeO0o4DIYWHLgGNi/X64T+X4Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"temp-dir": "^3.0.0"
@@ -11664,6 +11718,7 @@
 			"version": "3.19.3",
 			"resolved": "https://registry.npmmirror.com/uglify-js/-/uglify-js-3.19.3.tgz",
 			"integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"optional": true,
 			"bin": {
@@ -11703,6 +11758,7 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmmirror.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
 			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -11875,6 +11931,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmmirror.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"spdx-correct": "^3.0.0",
@@ -12018,6 +12075,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmmirror.com/wordwrap/-/wordwrap-1.0.0.tgz",
 			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
 		"@typescript-eslint/eslint-plugin": "8.49.0",
 		"@typescript-eslint/parser": "^8.49.0",
 		"builtin-modules": "5.0.0",
+		"conventional-changelog-cli": "^5.0.0",
+		"dotenv": "^17.2.3",
 		"esbuild": "0.27.1",
 		"eslint": "^9.39.2",
 		"eslint-plugin-obsidianmd": "^0.1.9",
@@ -47,8 +49,6 @@
 		"typescript": "^5.9.3"
 	},
 	"dependencies": {
-		"conventional-changelog-cli": "^5.0.0",
-		"dotenv": "^17.2.3",
 		"lucide-react": "^0.561.0",
 		"radix-ui": "^1.4.3",
 		"react": "^19.2.3",


### PR DESCRIPTION
将部分开发依赖项在 package-lock.json 中移动到 dev
字段（"dev": true），并调整 conventional-changelog-cli 与
dotenv 在依赖列表中的位置。这样做的目的是修正锁文件中
依赖的分类与位置，确保开发依赖被正确标记为 devDependencies，
提高安装与审计时的准确性并减少生产环境安装体积。