### PR TITLE
feat: 改进目录导航器的拖拽调整体验

### DIFF
--- a/src/components/toc-navigator/TocNavigator.css
+++ b/src/components/toc-navigator/TocNavigator.css
@@ -27,7 +27,7 @@
 		}
 
 		.NToc__group-resize {
-			right: -2px; /* 调整到容器右边缘外侧 */
+			right: -6px;
 		}
 
 		.NToc__return-tools {
@@ -66,7 +66,7 @@
 		}
 
 		.NToc__group-resize {
-			left: -2px; /* 调整到容器左边缘外侧 */
+			left: -6px;
 		}
 
 		.NToc__return-tools {
@@ -189,14 +189,53 @@
 	top: 0;
 	bottom: 0;
 	height: auto;
-	width: 4px;
+	width: 12px;
 	cursor: ew-resize;
 	background: transparent;
-	transition: background-color 150ms ease;
-	z-index: 1;
+	transition: background-color 150ms ease, opacity 150ms ease;
+	z-index: 3;
+	opacity: 0.35;
+
+	&::before {
+		content: "";
+		position: absolute;
+		top: 10px;
+		bottom: 10px;
+		left: 50%;
+		width: 3px;
+		transform: translateX(-50%);
+		border-radius: 999px;
+		background-color: var(--background-modifier-border);
+		transition:
+			background-color 150ms ease,
+			width 150ms ease,
+			opacity 150ms ease;
+		opacity: 0.65;
+	}
 
 	&:hover {
+		opacity: 1;
+
+		&::before {
+			width: 4px;
+			background-color: var(--interactive-accent);
+			opacity: 1;
+		}
+	}
+}
+
+.NToc__toc-items:hover .NToc__group-resize,
+.NToc__toc-items.NToc__toc-items-resizing .NToc__group-resize {
+	opacity: 0.85;
+}
+
+.NToc__toc-items.NToc__toc-items-resizing {
+	user-select: none;
+
+	.NToc__group-resize::before {
+		width: 4px;
 		background-color: var(--interactive-accent);
+		opacity: 1;
 	}
 }
 

--- a/src/components/toc-navigator/TocNavigator.tsx
+++ b/src/components/toc-navigator/TocNavigator.tsx
@@ -77,7 +77,7 @@ export const TocNavigator: FC<TocNavigatorProps> = ({
 	);
 
 	// 使用可调整大小 Hook
-	const { handleMouseDragStart } = useResizableToc({
+	const { handleMouseDragStart, isMouseDragging } = useResizableToc({
 		currentView,
 		tocItemsRef: NTocGroupTocItemsRef,
 		tocWidth: settings.toc.width,
@@ -200,11 +200,12 @@ export const TocNavigator: FC<TocNavigatorProps> = ({
 					{shouldShowToc && (
 						<div
 							ref={NTocGroupTocItemsRef}
-							className="NToc__toc-items"
+							className={`NToc__toc-items ${isMouseDragging ? "NToc__toc-items-resizing" : ""}`}
 						>
 							<div
 								className="NToc__group-resize"
 								onMouseDown={handleMouseDragStart}
+								aria-hidden="true"
 							/>
 							{settings.tool.showProgressBar && (
 								<div


### PR DESCRIPTION
增强了目录导航器的拖拽调整功能。扩大了调整
手柄的可点击区域，从 4px 增加到 12px，提高
了易用性。添加了视觉反馈，包括手柄的透明度
变化和悬停时的样式更新。在拖拽过程中添加了
动态样式类，防止文本选择并提供更好的视觉
反馈。调整了手柄的位置偏移量，确保在不同
布局方向下的准确性。