### PR TITLE
fix: 修正预检查工作流中的构建产物路径

### DIFF
--- a/.github/workflows/precheck.yml
+++ b/.github/workflows/precheck.yml
@@ -76,7 +76,7 @@ jobs:
 
                   # 构建产物检查
                   echo "📦 Verifying build artifacts..."
-                  required_files=("main.js" "manifest.json" "styles.css")
+                  required_files=("dist/main.js" "dist/manifest.json" "dist/styles.css")
                   missing_files=()
 
                   for file in "${required_files[@]}"; do
@@ -97,7 +97,7 @@ jobs:
                   # 版本一致性检查
                   echo "🔢 Checking version consistency..."
                   package_version=$(node -p "require('./package.json').version")
-                  manifest_version=$(node -p "require('./manifest.json').version")
+                  manifest_version=$(node -p "require('./dist/manifest.json').version")
 
                   echo "Package.json version: $package_version"
                   echo "Manifest.json version: $manifest_version"


### PR DESCRIPTION
更新预检查工作流中的文件路径，将构建产物的
检查路径从根目录改为 dist 目录。这确保工作流
能够正确验证实际输出的构建产物位置，包括
main.js、manifest.json 和 styles.css 文件，
以及版本一致性检查中的 manifest.json 路径。